### PR TITLE
Fix typo which breaks BoxWidget collapsing.

### DIFF
--- a/build/js/BoxWidget.js
+++ b/build/js/BoxWidget.js
@@ -101,7 +101,7 @@
         $(this.element).addClass(ClassName.collapsed);
         $(this.element).trigger(collapsedEvent);
       }.bind(this))
-      .trigger(expandingEvent);
+      .trigger(collapsingEvent);
   };
 
   BoxWidget.prototype.remove = function () {


### PR DESCRIPTION
On v2.4.9, BoxWidget collapsing is broken by a typo.
This patch fixes it.
