### PR TITLE
Update adminlte.js

### DIFF
--- a/dist/js/adminlte.js
+++ b/dist/js/adminlte.js
@@ -241,7 +241,7 @@ throw new Error('AdminLTE requires jQuery')
         $(this.element).addClass(ClassName.collapsed);
         $(this.element).trigger(collapsedEvent);
       }.bind(this))
-      .trigger(expandingEvent);
+      .trigger(collapsingEvent);
   };
 
   BoxWidget.prototype.remove = function () {


### PR DESCRIPTION
Fixing bug throwing error "Uncaught ReferenceError: expandingEvent is not defined" when collapsing .box .

See #2088 for more informations.