### PR TITLE
Fix wrong label column number

### DIFF
--- a/pages/forms/general.html
+++ b/pages/forms/general.html
@@ -721,14 +721,14 @@
               <form class="form-horizontal">
                 <div class="card-body">
                   <div class="form-group">
-                    <label for="inputEmail3" class="col-sm-2 control-label">Email</label>
+                    <label for="inputEmail3" class="col-sm-4 control-label">Email</label>
 
                     <div class="col-sm-10">
                       <input type="email" class="form-control" id="inputEmail3" placeholder="Email">
                     </div>
                   </div>
                   <div class="form-group">
-                    <label for="inputPassword3" class="col-sm-2 control-label">Password</label>
+                    <label for="inputPassword3" class="col-sm-4 control-label">Password</label>
 
                     <div class="col-sm-10">
                       <input type="password" class="form-control" id="inputPassword3" placeholder="Password">


### PR DESCRIPTION
It causes label text to wrap to the next line

**BEFORE**
![image](https://user-images.githubusercontent.com/23640357/56791962-13864000-67ce-11e9-9b9d-4229efd0506c.png)

**AFTER**
![image](https://user-images.githubusercontent.com/23640357/56792027-37498600-67ce-11e9-8c70-791fdf91f825.png)

