### PR TITLE
Package.json -> scripts. Module "cleancss"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ ad.js
 TODO
 test.html
 .vscode/
+.vs/

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "css": "npm-run-all --sequential css-compile css-prefix css-minify",
     "css-compile": "node-sass --output-style expanded --source-map true --source-map-contents true --precision 6 build/scss/AdminLTE.scss dist/css/adminlte.css",
     "css-prefix": "postcss --config build/config/postcss.config.js --replace \"dist/css/*.css\" \"!dist/css/*.min.css\"",
-    "css-minify": "cleancss --level 1 --source-map dist/css/adminlte.css.map --output dist/css/adminlte.min.css dist/css/adminlte.css",
+    "css-minify": "cleancss --level 1 --source-map --output dist/css/adminlte.min.css dist/css/adminlte.css",
     "compile": "npm-run-all --parallel js css",
     "dev": "npm-run-all --parallel watch sync",
     "js": "npm-run-all --sequential js-compile js-minify",


### PR DESCRIPTION
According to the documentation module "cleancss".
To generate a source map, use --source-map switch, e.g.:
cleancss --source-map --output styles.min.css styles.css
Name of the output file is required, so a map file, named by adding .map suffix to output file name, can be created (styles.min.css.map in this case).

If you do not make changes, then when executing the "css-minify" script, a warning is issued:

+ npm : WARNING: Empty selector '' at dist/css/adminlte.css.map:1:0. Ignoring. line:1 sign:1
+ ~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (WARNING: Empty ...:1:0. Ignoring.:String) [], RemoteException
    + FullyQualifiedErrorId : NativeCommandError
+ WARNING: Invalid property name '"version"' at dist/css/adminlte.css.map:1:1. Ignoring.