### PR TITLE
Change "js-compile" script. Moving settings files to one place.

### DIFF
--- a/build/config/rollup.config.js
+++ b/build/config/rollup.config.js
@@ -1,6 +1,6 @@
 import babel from 'rollup-plugin-babel'
 
-const pkg  = require('./package')
+const pkg  = require('../../package')
 const year = new Date().getFullYear()
 
 const globals = {
@@ -22,7 +22,8 @@ export default {
   },
   plugins: [
     babel({
-      exclude: 'node_modules/**'
+      exclude: 'node_modules/**',
+      externalHelpers: true
     })
   ]
 }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "compile": "npm-run-all --parallel js css",
     "dev": "npm-run-all --parallel watch sync",
     "js": "npm-run-all --sequential js-compile js-minify",
-    "js-compile": "rollup -c --sourcemap",
+    "js-compile": "rollup --config build/config/rollup.config.js --sourcemap",
     "js-minify": "uglifyjs --compress typeofs=false --mangle --comments \"/^!/\" --source-map \"content=dist/js/adminlte.js.map,includeSources,url=adminlte.min.js.map\" --output dist/js/adminlte.min.js dist/js/adminlte.js",
     "production": "npm-run-all --parallel compile && node build/npm/Publish.js -v",
     "plugins": "node build/npm/Publish.js -v",


### PR DESCRIPTION
1. Moving settings files to one place.

2. Warning correction.
>  Babel plugin: Using "external-helpers" plugin with rollup-plugin-babel is deprecated, as it now. automatically deduplicates your Babel helpers.
![pr1](https://user-images.githubusercontent.com/50718918/61052945-2683d600-a3f5-11e9-9dff-04a83ee0e281.png)