### PR TITLE
Updating devDependencies for "js-compile" script.

### DIFF
--- a/build/config/rollup.config.js
+++ b/build/config/rollup.config.js
@@ -23,7 +23,7 @@ export default {
   plugins: [
     babel({
       exclude: 'node_modules/**',
-      externalHelpers: true
+      babelHelpers: "external"
     })
   ]
 }

--- a/package.json
+++ b/package.json
@@ -82,10 +82,10 @@
     "toastr": "^2.1.4"
   },
   "devDependencies": {
-    "@babel/cli": "^7.4.4",
-    "@babel/core": "^7.4.5",
+    "@babel/cli": "^7.5.0",
+    "@babel/core": "^7.5.4",
     "@babel/plugin-external-helpers": "^7.2.0",
-    "@babel/preset-env": "^7.4.5",
+    "@babel/preset-env": "^7.5.4",
     "autoprefixer": "^8.6.5",
     "babel-eslint": "^8.2.6",
     "browser-sync": "^2.26.7",
@@ -101,8 +101,8 @@
     "npm-run-all": "^4.1.5",
     "path": "^0.12.7",
     "postcss-cli": "^5.0.1",
-    "rollup": "^1.15.1",
-    "rollup-plugin-babel": "^4.3.2",
+    "rollup": "^1.16.7",
+    "rollup-plugin-babel": "^5.0.0-alpha.0",
     "style-loader": "^0.19.1",
     "uglify-js": "^3.6.0"
   }


### PR DESCRIPTION
Updating "rollup-plugin-babel" from version 4.* to version  5.*.
The configuration file was also updated due to the module configuration requirements below.
Warning: new version of the module "rollup-plugin-babel" is in alpha stage. 
![rollup 4 to 5](https://user-images.githubusercontent.com/50718918/61131903-f9055e00-a4c2-11e9-867a-0fa1f7715bd1.png)
