### PR TITLE
Build on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,24 @@
+language: node_js
+
+node_js:
+  - 8
+  - 9
+  - 10
+  - 11
+  - 12
+
+env:
+  - INSTALL=bower
+  - INSTALL=yarn
+  - INSTALL=npm
+
+matrix:
+  fast_finish: true
+
+install:
+  - if [ "bower" == $INSTALL ]; then yarn global add bower && bower install; fi
+  - if [ "yarn" == $INSTALL ]; then yarn install; fi
+  - if [ "npm" == $INSTALL ]; then npm install; fi
+
+script:
+  - echo 'Tests must be configured'

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 Introduction
 ============
 
+[![Build Status](https://img.shields.io/travis/ColorlibHQ/AdminLTE.svg)](https://travis-ci.org/ColorlibHQ/AdminLTE)
 ![Bower version](https://img.shields.io/bower/v/adminlte.svg)
 [![npm version](https://img.shields.io/npm/v/admin-lte.svg)](https://www.npmjs.com/package/admin-lte)
 [![Packagist](https://img.shields.io/packagist/v/almasaeed2010/adminlte.svg)](https://packagist.org/packages/almasaeed2010/adminlte)
@@ -42,7 +43,7 @@ reserves the right to change the license of future releases. Wondering what you 
 AdminLTE 1.x can be easily upgraded to 2.x using [this guide](https://adminlte.io/themes/AdminLTE/documentation/index.html#upgrade), but if you intend to keep using AdminLTE 1.x, you can download the latest release from the [releases](https://github.com/ColorlibHQ/AdminLTE/releases) section above.
 
 ### Change log
-**For the most recent change log, visit the [releases page](https://github.com/ColorlibHQ/AdminLTE/releases) or the [changelog file](https://github.com/ColorlibHQ/AdminLTE/blob/master/changelog.md).** We will add detailed release notes to each new release. 
+**For the most recent change log, visit the [releases page](https://github.com/ColorlibHQ/AdminLTE/releases) or the [changelog file](https://github.com/ColorlibHQ/AdminLTE/blob/master/changelog.md).** We will add detailed release notes to each new release.
 
 ### Image Credits
 - [Pixeden](http://www.pixeden.com/psd-web-elements/flat-responsive-showcase-psd)


### PR DESCRIPTION
For a sample build, see https://travis-ci.org/phansys/AdminLTE/builds/559747706.

In order to get this working, you must enable the project at Travis CI: https://travis-ci.org/ColorlibHQ/AdminLTE.

`README.md` was also updated to include the build status badge.

By now, the build executes the install steps using NPM and Bower, which allows us to detect any problem caused by these processes.
There are no tests running yet since the project itself has no tests. When they are added, the `script` configuration at `.travis.yml` must be updated.
