### PR TITLE
Changing module to work with the file system. Remove 'ncp'.

### DIFF
--- a/build/npm/Publish.js
+++ b/build/npm/Publish.js
@@ -1,5 +1,5 @@
 const Plugins = require('./Plugins')
-const ncp     = require('ncp').ncp
+const fse     = require('fs-extra')
 
 class Publish {
   constructor() {
@@ -27,7 +27,7 @@ class Publish {
   run() {
     // Publish files
     Plugins.forEach((module) => {
-      ncp(module.from, module.to, error => {
+      fse.copy(module.from, module.to, error => {
         if (error) {
           console.error(`Error: ${error}`)
         } else if (this.options.verbose) {

--- a/package.json
+++ b/package.json
@@ -96,7 +96,6 @@
     "eslint-plugin-compat": "^2.7.0",
     "extract-text-webpack-plugin": "^3.0.2",
     "fs-extra": "^5.0.0",
-    "ncp": "^2.0.0",
     "node-sass": "^4.12.0",
     "nodemon": "^1.19.1",
     "npm-run-all": "^4.1.5",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "js": "npm-run-all --sequential js-compile js-minify",
     "js-compile": "rollup --config build/config/rollup.config.js --sourcemap",
     "js-minify": "terser --compress typeofs=false --mangle --comments \"/^!/\" --source-map \"content=dist/js/adminlte.js.map,includeSources,url=adminlte.min.js.map\" --output dist/js/adminlte.min.js dist/js/adminlte.js",
-    "production": "npm-run-all --parallel compile && node build/npm/Publish.js -v",
+    "production": "npm-run-all --parallel compile plugins",
     "plugins": "node build/npm/Publish.js -v",
     "sync": "browser-sync start --server --files *.html pages/ dist/",
     "watch": "npm-run-all --parallel watch-css watch-js",


### PR DESCRIPTION
My environment: win7-x64.
If deleted the folder 'plugins' and calling: ``` npm run-script plugins ``` I get an error
![ENOENTmkdirError](https://user-images.githubusercontent.com/50718918/61576948-692a6a00-aae9-11e9-8fe5-444d7312cea2.png)
Module 'ncp' cannot recursively create new folders for copying files from another directory into them.
Maybe this problem only windows system, but if using the module 'fs-extra' - this problem disappears.
Module 'ncp' is the oldest and has not been updated for a long time compared to 'fs-extra'.