### PR TITLE
Fix for table-valign-middle doesn't work

### DIFF
--- a/build/scss/_table.scss
+++ b/build/scss/_table.scss
@@ -48,7 +48,7 @@
     }
   }
 
-  .table-valign-middle {
+  &.table-valign-middle {
     thead > tr > th,
     thead > tr > td,
     tbody > tr > th,


### PR DESCRIPTION
At v3-beta1, `.table-valign-middle` class worked correctly, but now it doesn't. I think this class is set at the `table` tag, so this fix is needed.