### PR TITLE
Update _select2.scss

### DIFF
--- a/build/scss/plugins/_select2.scss
+++ b/build/scss/plugins/_select2.scss
@@ -37,7 +37,7 @@
 
   & .select2-selection--single .select2-selection__rendered {
     padding-left: 0;
-    padding-right: 0;
+    //padding-right: 0;
     height: auto;
     margin-top: -3px;
   }


### PR DESCRIPTION
The arrow down overrides the clear "x" button.
Removing this padding-right: 0 fix this issue.