### PR TITLE
Update _select2.scss

### DIFF
--- a/build/scss/plugins/_select2.scss
+++ b/build/scss/plugins/_select2.scss
@@ -115,7 +115,7 @@
   & {
     .select2-selection--multiple {
       border: $input-border-width solid $input-border-color;
-      height: $input-height;
+      //height: $input-height;
 
       &:focus {
         border-color: $input-focus-border-color;


### PR DESCRIPTION
By defining an heigh for multiple selection, the selection box doens't follow the contents heigh.
You can even test this on your demo page.
By removing this property this issue is fixed.