### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Contribution are always **welcome and recommended**! Here is how:
 To compile the dist files you need nodejs/npm, clone/download the repo then:
 
 1. `npm install` (install npm deps)
-2. _Optional:_ `npm dev` (developer mode, autocompile with browsersync support for live demo)
+2. _Optional:_ `npm run dev` (developer mode, autocompile with browsersync support for live demo)
 3. `npm run production` (compile css/js files)
 
 #### Contribution Requirements:


### PR DESCRIPTION
After cloning as per instructions `npm dev` produces the following error:
```
Usage: npm <command>

where <command> is one of:
    access, adduser, audit, bin, bugs, c, cache, ci, cit,
    clean-install, clean-install-test, completion, config,
    create, ddp, dedupe, deprecate, dist-tag, docs, doctor,
    edit, explore, fund, get, help, help-search, hook, i, init,
    install, install-ci-test, install-test, it, link, list, ln,
    login, logout, ls, org, outdated, owner, pack, ping, prefix,
    profile, prune, publish, rb, rebuild, repo, restart, root,
    run, run-script, s, se, search, set, shrinkwrap, star,
    stars, start, stop, t, team, test, token, tst, un,
    uninstall, unpublish, unstar, up, update, v, version, view,
    whoami
```