### PR TITLE
Fixed double border on cards with nav tabs

### DIFF
--- a/build/scss/_cards.scss
+++ b/build/scss/_cards.scss
@@ -2,6 +2,15 @@
 // Component: Cards
 //
 
+// Color variants
+@each $name, $color in $theme-colors {
+  @include cards-variant($name, $color);
+}
+
+@each $name, $color in $colors {
+  @include cards-variant($name, $color);
+}
+
 .card {
   @include box-shadow($card-shadow);
   margin-bottom: map-get($spacers, 3);
@@ -211,7 +220,7 @@ html.maximized-card {
   }
 
   .nav-link {
-    padding: $card-nav-link-padding-sm-y $card-nav-link-padding-sm-x; 
+    padding: $card-nav-link-padding-sm-y $card-nav-link-padding-sm-x;
   }
 }
 
@@ -400,16 +409,6 @@ html.maximized-card {
 .card-input {
   max-width: 200px;
 }
-
-// Color variants
-@each $name, $color in $theme-colors {
-  @include cards-variant($name, $color);
-}
-
-@each $name, $color in $colors {
-  @include cards-variant($name, $color);
-}
-
 
 // Nav Tabs override
 .card-default {


### PR DESCRIPTION
Card color mixins were included after main card CSS in _cards.scss causing cards with the .card-outline-tabs to have part of their CSS overridden causing a doubled border. Simply changing the order of the CSS rules fixed the issue.

Tab card with .card-outline-tabs on MASTER:
![Card_Nav_Tab_Broken](https://user-images.githubusercontent.com/7804676/71883796-712da300-3137-11ea-9adc-cea86e4ef62e.png)

Tab card with .card-outline-tabs after fix:
![Card_Nav_Tab_Fixed](https://user-images.githubusercontent.com/7804676/71883836-8571a000-3137-11ea-8a44-04e65f908603.png)
