### PR TITLE
Cleanup Gemfile and add wdm on Windows

### DIFF
--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -1,7 +1,4 @@
 source 'https://rubygems.org'
 
-gem "jekyll", "~> 3.8.5"
-
-gem "rouge"
-
-gem 'github-pages', group: :jekyll_plugins
+gem 'github-pages'
+gem 'wdm', '~> 0.1.1', :install_if => Gem.win_platform?


### PR DESCRIPTION
@REJack do you build the docs locally only? If so, maybe you don't need the `github-pages` gem which installs 85(!) gems.

But I'll leave that for you to tackle later. This patch removes redundant gems; `github-pages` gem includes those.

EDIT: also is generally good practice to include Gemfile.lock in the repo, like you do with package-lock.json. And perhaps specify a version for the `github-pages` gem; now it installs the latest all the time.