### PR TITLE
Update CI config

### DIFF
--- a/.github/workflows/node-install.yml
+++ b/.github/workflows/node-install.yml
@@ -3,11 +3,14 @@
 
 name: Node.js Install Test
 
-on: 
+on:
   pull_request:
   release:
     types:
       - created
+
+env:
+  CI: true
 
 jobs:
   install-ubuntu:
@@ -15,7 +18,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 13.x, 14.x]
+        node-version: [10.x, 12.x, 14.x]
 
     steps:
     - uses: actions/checkout@v2
@@ -23,14 +26,14 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
-    - run: npm install
+    - run: npm ci
 
   install-macos:
     runs-on: macos-latest
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 13.x, 14.x]
+        node-version: [10.x, 12.x, 14.x]
 
     steps:
     - uses: actions/checkout@v2
@@ -38,14 +41,14 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
-    - run: npm install
+    - run: npm ci
 
   install-windows:
     runs-on: windows-latest
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 13.x] #14.x doesn't work properly on GitHub actions
+        node-version: [10.x, 12.x, 14.x]
 
     steps:
     - uses: actions/checkout@v2
@@ -53,4 +56,4 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
-    - run: npm install
+    - run: npm ci


### PR DESCRIPTION
* remove the non-LTS Node.js 13
* specify `CI: true` environment variable
* switch to `npm ci` which checks for package-lock.json and it's intended for CI

I'm marking it as draft to check any failures and fix them. Also, ideally the other deps PRs should land first, so I'll wait to rebase this.

EDIT: the failures should be fixed after the deps PRs are merged, so let's wait a bit :) Also, CI should be faster after the deps PRs and this lands.