### PR TITLE
Enforce LF.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Enforce Unix newlines
+* text=auto eol=lf


### PR DESCRIPTION
On Windows with `autocrlf: true`, which is the default, we ended up with modified files.

Do note that this requires git >= 2.10. I personally find this solution a lot simpler than having to specify each file extension.