### PR TITLE
Update jQuery to v3.5.1.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7583,9 +7583,9 @@
       "integrity": "sha1-o6vicYryQaKykE+EpiWXDzia4yo="
     },
     "jquery": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.4.1.tgz",
-      "integrity": "sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw=="
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.5.1.tgz",
+      "integrity": "sha512-XwIBPqcMn57FxfT+Go5pzySnm4KWkT1Tv7gjrpT1srtf8Weynl6R273VJ5GjkRb51IzMp5nbaPjJXMWeju2MKg=="
     },
     "jquery-knob-chif": {
       "version": "1.2.13",

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "icheck-bootstrap": "^3.0.1",
     "inputmask": "^5.0.3",
     "ion-rangeslider": "^2.3.1",
-    "jquery": "^3.4.1",
+    "jquery": "^3.5.1",
     "jquery-knob-chif": "^1.2.13",
     "jquery-mapael": "^2.2.0",
     "jquery-mousewheel": "^3.1.13",


### PR DESCRIPTION
Fixes #2714.

@REJack opened the PR but needs testing from your side. No hurry of course :)

This leaves 3 npm audit errors coming from one devDependency on master.