### PR TITLE
docs: fix HTML errors

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -21,10 +21,10 @@ highlighter: rouge
 plugins:
   - jekyll-seo-tag
 
-title: AdminLTE v3 Documentaion
+title: AdminLTE v3 Documentation
 version: v3.0.5
 description: >- # this means to ignore newlines until "baseurl:"
-  AdminLTE v3 Documentaion
+  AdminLTE v3 Documentation
 
 navigation:
 - title: Installation

--- a/docs/_includes/head.html
+++ b/docs/_includes/head.html
@@ -3,7 +3,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta http-equiv="x-ua-compatible" content="ie=edge">
 
-    <title>{{ page.title }} | AdminLTE 3 Documentation</title>
     {% seo %}
     
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,400i,700">

--- a/docs/_includes/navbar.html
+++ b/docs/_includes/navbar.html
@@ -11,7 +11,7 @@
           <a class="dropdown-item bg-info disabled" href="#">v3.0</a>
           <div class="dropdown-divider"></div>
           <a class="dropdown-item" href="https://adminlte.io/docs/2.4/installation">v2.4</a>
-          <a class="dropdown-item" href="https://adminlte.io/themes/AdminLTE/documentation/index.html"><= v2.3</a>
+          <a class="dropdown-item" href="https://adminlte.io/themes/AdminLTE/documentation/index.html">&lt;= v2.3</a>
         </div>
       </li>
     </ul>

--- a/docs/components/direct-chat.md
+++ b/docs/components/direct-chat.md
@@ -70,7 +70,7 @@ The direct chat widget extends the card component to create a beautiful chat int
           <ul class="contacts-list">
             <li>
               <a href="#">
-                <img class="contacts-list-img" src="{{'assets/img/user1-128x128.jpg' | relative_url}}">
+                <img class="contacts-list-img" src="{{'assets/img/user1-128x128.jpg' | relative_url}}" alt="message user image">
                 <div class="contacts-list-info">
                   <span class="contacts-list-name">
                     Count Dracula
@@ -82,7 +82,7 @@ The direct chat widget extends the card component to create a beautiful chat int
             </li>
             <li>
               <a href="#">
-                <img class="contacts-list-img" src="{{'assets/img/user7-128x128.jpg' | relative_url}}">
+                <img class="contacts-list-img" src="{{'assets/img/user7-128x128.jpg' | relative_url}}" alt="message user image">
                 <div class="contacts-list-info">
                   <span class="contacts-list-name">
                     Sarah Doe
@@ -94,7 +94,7 @@ The direct chat widget extends the card component to create a beautiful chat int
             </li>
             <li>
               <a href="#">
-                <img class="contacts-list-img" src="{{'assets/img/user3-128x128.jpg' | relative_url}}">
+                <img class="contacts-list-img" src="{{'assets/img/user3-128x128.jpg' | relative_url}}" alt="message user image">
                 <div class="contacts-list-info">
                   <span class="contacts-list-name">
                     Nadia Jolie
@@ -106,7 +106,7 @@ The direct chat widget extends the card component to create a beautiful chat int
             </li>
             <li>
               <a href="#">
-                <img class="contacts-list-img" src="{{'assets/img/user5-128x128.jpg' | relative_url}}">
+                <img class="contacts-list-img" src="{{'assets/img/user5-128x128.jpg' | relative_url}}" alt="message user image">
                 <div class="contacts-list-info">
                   <span class="contacts-list-name">
                     Nora S. Vans
@@ -118,7 +118,7 @@ The direct chat widget extends the card component to create a beautiful chat int
             </li>
             <li>
               <a href="#">
-                <img class="contacts-list-img" src="{{'assets/img/user6-128x128.jpg' | relative_url}}">
+                <img class="contacts-list-img" src="{{'assets/img/user6-128x128.jpg' | relative_url}}" alt="message user image">
                 <div class="contacts-list-info">
                   <span class="contacts-list-name">
                     John K.
@@ -130,7 +130,7 @@ The direct chat widget extends the card component to create a beautiful chat int
             </li>
             <li>
               <a href="#">
-                <img class="contacts-list-img" src="{{'assets/img/user8-128x128.jpg' | relative_url}}">
+                <img class="contacts-list-img" src="{{'assets/img/user8-128x128.jpg' | relative_url}}" alt="message user image">
                 <div class="contacts-list-info">
                   <span class="contacts-list-name">
                     Kenneth M.
@@ -219,7 +219,7 @@ The direct chat widget extends the card component to create a beautiful chat int
           <ul class="contacts-list">
             <li>
               <a href="#">
-                <img class="contacts-list-img" src="{{'assets/img/user1-128x128.jpg' | relative_url}}">
+                <img class="contacts-list-img" src="{{'assets/img/user1-128x128.jpg' | relative_url}}" alt="message user image">
                 <div class="contacts-list-info">
                   <span class="contacts-list-name">
                     Count Dracula
@@ -231,7 +231,7 @@ The direct chat widget extends the card component to create a beautiful chat int
             </li>
             <li>
               <a href="#">
-                <img class="contacts-list-img" src="{{'assets/img/user7-128x128.jpg' | relative_url}}">
+                <img class="contacts-list-img" src="{{'assets/img/user7-128x128.jpg' | relative_url}}" alt="message user image">
                 <div class="contacts-list-info">
                   <span class="contacts-list-name">
                     Sarah Doe
@@ -243,7 +243,7 @@ The direct chat widget extends the card component to create a beautiful chat int
             </li>
             <li>
               <a href="#">
-                <img class="contacts-list-img" src="{{'assets/img/user3-128x128.jpg' | relative_url}}">
+                <img class="contacts-list-img" src="{{'assets/img/user3-128x128.jpg' | relative_url}}" alt="message user image">
                 <div class="contacts-list-info">
                   <span class="contacts-list-name">
                     Nadia Jolie
@@ -255,7 +255,7 @@ The direct chat widget extends the card component to create a beautiful chat int
             </li>
             <li>
               <a href="#">
-                <img class="contacts-list-img" src="{{'assets/img/user5-128x128.jpg' | relative_url}}">
+                <img class="contacts-list-img" src="{{'assets/img/user5-128x128.jpg' | relative_url}}" alt="message user image">
                 <div class="contacts-list-info">
                   <span class="contacts-list-name">
                     Nora S. Vans
@@ -267,7 +267,7 @@ The direct chat widget extends the card component to create a beautiful chat int
             </li>
             <li>
               <a href="#">
-                <img class="contacts-list-img" src="{{'assets/img/user6-128x128.jpg' | relative_url}}">
+                <img class="contacts-list-img" src="{{'assets/img/user6-128x128.jpg' | relative_url}}" alt="message user image">
                 <div class="contacts-list-info">
                   <span class="contacts-list-name">
                     John K.
@@ -279,7 +279,7 @@ The direct chat widget extends the card component to create a beautiful chat int
             </li>
             <li>
               <a href="#">
-                <img class="contacts-list-img" src="{{'assets/img/user8-128x128.jpg' | relative_url}}">
+                <img class="contacts-list-img" src="{{'assets/img/user8-128x128.jpg' | relative_url}}" alt="message user image">
                 <div class="contacts-list-info">
                   <span class="contacts-list-name">
                     Kenneth M.
@@ -570,7 +570,7 @@ Of course you can use direct chat with a outline card by adding the class `.card
           <ul class="contacts-list">
             <li>
               <a href="#">
-                <img class="contacts-list-img" src="{{'assets/img/user1-128x128.jpg' | relative_url}}">
+                <img class="contacts-list-img" src="{{'assets/img/user1-128x128.jpg' | relative_url}}" alt="message user image">
                 <div class="contacts-list-info">
                   <span class="contacts-list-name">
                     Count Dracula
@@ -582,7 +582,7 @@ Of course you can use direct chat with a outline card by adding the class `.card
             </li>
             <li>
               <a href="#">
-                <img class="contacts-list-img" src="{{'assets/img/user7-128x128.jpg' | relative_url}}">
+                <img class="contacts-list-img" src="{{'assets/img/user7-128x128.jpg' | relative_url}}" alt="message user image">
                 <div class="contacts-list-info">
                   <span class="contacts-list-name">
                     Sarah Doe
@@ -594,7 +594,7 @@ Of course you can use direct chat with a outline card by adding the class `.card
             </li>
             <li>
               <a href="#">
-                <img class="contacts-list-img" src="{{'assets/img/user3-128x128.jpg' | relative_url}}">
+                <img class="contacts-list-img" src="{{'assets/img/user3-128x128.jpg' | relative_url}}" alt="message user image">
                 <div class="contacts-list-info">
                   <span class="contacts-list-name">
                     Nadia Jolie
@@ -606,7 +606,7 @@ Of course you can use direct chat with a outline card by adding the class `.card
             </li>
             <li>
               <a href="#">
-                <img class="contacts-list-img" src="{{'assets/img/user5-128x128.jpg' | relative_url}}">
+                <img class="contacts-list-img" src="{{'assets/img/user5-128x128.jpg' | relative_url}}" alt="message user image">
                 <div class="contacts-list-info">
                   <span class="contacts-list-name">
                     Nora S. Vans
@@ -618,7 +618,7 @@ Of course you can use direct chat with a outline card by adding the class `.card
             </li>
             <li>
               <a href="#">
-                <img class="contacts-list-img" src="{{'assets/img/user6-128x128.jpg' | relative_url}}">
+                <img class="contacts-list-img" src="{{'assets/img/user6-128x128.jpg' | relative_url}}" alt="message user image">
                 <div class="contacts-list-info">
                   <span class="contacts-list-name">
                     John K.
@@ -630,7 +630,7 @@ Of course you can use direct chat with a outline card by adding the class `.card
             </li>
             <li>
               <a href="#">
-                <img class="contacts-list-img" src="{{'assets/img/user8-128x128.jpg' | relative_url}}">
+                <img class="contacts-list-img" src="{{'assets/img/user8-128x128.jpg' | relative_url}}" alt="message user image">
                 <div class="contacts-list-info">
                   <span class="contacts-list-name">
                     Kenneth M.
@@ -719,7 +719,7 @@ Of course you can use direct chat with a outline card by adding the class `.card
           <ul class="contacts-list">
             <li>
               <a href="#">
-                <img class="contacts-list-img" src="{{'assets/img/user1-128x128.jpg' | relative_url}}">
+                <img class="contacts-list-img" src="{{'assets/img/user1-128x128.jpg' | relative_url}}" alt="message user image">
                 <div class="contacts-list-info">
                   <span class="contacts-list-name">
                     Count Dracula
@@ -731,7 +731,7 @@ Of course you can use direct chat with a outline card by adding the class `.card
             </li>
             <li>
               <a href="#">
-                <img class="contacts-list-img" src="{{'assets/img/user7-128x128.jpg' | relative_url}}">
+                <img class="contacts-list-img" src="{{'assets/img/user7-128x128.jpg' | relative_url}}" alt="message user image">
                 <div class="contacts-list-info">
                   <span class="contacts-list-name">
                     Sarah Doe
@@ -743,7 +743,7 @@ Of course you can use direct chat with a outline card by adding the class `.card
             </li>
             <li>
               <a href="#">
-                <img class="contacts-list-img" src="{{'assets/img/user3-128x128.jpg' | relative_url}}">
+                <img class="contacts-list-img" src="{{'assets/img/user3-128x128.jpg' | relative_url}}" alt="message user image">
                 <div class="contacts-list-info">
                   <span class="contacts-list-name">
                     Nadia Jolie
@@ -755,7 +755,7 @@ Of course you can use direct chat with a outline card by adding the class `.card
             </li>
             <li>
               <a href="#">
-                <img class="contacts-list-img" src="{{'assets/img/user5-128x128.jpg' | relative_url}}">
+                <img class="contacts-list-img" src="{{'assets/img/user5-128x128.jpg' | relative_url}}" alt="message user image">
                 <div class="contacts-list-info">
                   <span class="contacts-list-name">
                     Nora S. Vans
@@ -767,7 +767,7 @@ Of course you can use direct chat with a outline card by adding the class `.card
             </li>
             <li>
               <a href="#">
-                <img class="contacts-list-img" src="{{'assets/img/user6-128x128.jpg' | relative_url}}">
+                <img class="contacts-list-img" src="{{'assets/img/user6-128x128.jpg' | relative_url}}" alt="message user image">
                 <div class="contacts-list-info">
                   <span class="contacts-list-name">
                     John K.
@@ -779,7 +779,7 @@ Of course you can use direct chat with a outline card by adding the class `.card
             </li>
             <li>
               <a href="#">
-                <img class="contacts-list-img" src="{{'assets/img/user8-128x128.jpg' | relative_url}}">
+                <img class="contacts-list-img" src="{{'assets/img/user8-128x128.jpg' | relative_url}}" alt="message user image">
                 <div class="contacts-list-info">
                   <span class="contacts-list-name">
                     Kenneth M.

--- a/docs/components/main-header.md
+++ b/docs/components/main-header.md
@@ -161,10 +161,10 @@ The main header contains the navbar. Construction of the navbar differs slightly
         <a href="#" class="nav-link">Contact</a>
       </li>
       <li class="nav-item dropdown">
-        <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+        <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown2" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
           Help
         </a>
-        <div class="dropdown-menu" aria-labelledby="navbarDropdown">
+        <div class="dropdown-menu" aria-labelledby="navbarDropdown2">
           <a class="dropdown-item" href="#">FAQ</a>
           <a class="dropdown-item" href="#">Support</a>
           <div class="dropdown-divider"></div>
@@ -310,10 +310,10 @@ Top navbar example can be found in this [demo page](https://adminlte.io/themes/d
         <a href="#" class="nav-link">Contact</a>
       </li>
       <li class="nav-item dropdown">
-        <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+        <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown3" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
           Help
         </a>
-        <div class="dropdown-menu" aria-labelledby="navbarDropdown">
+        <div class="dropdown-menu" aria-labelledby="navbarDropdown3">
           <a class="dropdown-item" href="#">FAQ</a>
           <a class="dropdown-item" href="#">Support</a>
           <div class="dropdown-divider"></div>
@@ -446,10 +446,10 @@ Top navbar example can be found in this [demo page](https://adminlte.io/themes/d
           <a href="#" class="nav-link">Contact</a>
         </li>
         <li class="nav-item dropdown">
-          <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+          <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown4" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
             Help
           </a>
-          <div class="dropdown-menu" aria-labelledby="navbarDropdown">
+          <div class="dropdown-menu" aria-labelledby="navbarDropdown4">
             <a class="dropdown-item" href="#">FAQ</a>
             <a class="dropdown-item" href="#">Support</a>
             <div class="dropdown-divider"></div>


### PR DESCRIPTION
* duplicate `title` tag; jekyll-seo-tag adds the title by default
* escape `<`
* fix duplicate IDs
* fix typo `Documentaion`
* add missing `alt` attributes in direct-chat.md