### PR TITLE
Fix prefix script to run for all CSS files

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "css-compile:extra-components": "npm run css-compile-bash -- build/scss/AdminLTE-extra-components.scss dist/css/alt/adminlte.extra-components.css",
     "css-compile:pages": "npm run css-compile-bash -- build/scss/AdminLTE-pages.scss dist/css/alt/adminlte.pages.css",
     "css-compile:plugins": "npm run css-compile-bash -- build/scss/AdminLTE-plugins.scss dist/css/alt/adminlte.plugins.css",
-    "css-prefix": "postcss --config build/config/postcss.config.js --replace \"dist/css/*.css\" \"!dist/css/*.min.css\"",
+    "css-prefix": "postcss --config build/config/postcss.config.js --replace \"dist/css/**/*.css\" \"!dist/css/**/*.min.css\"",
     "css-minify-bash": "cleancss --level 1 --source-map --source-map-inline-sources --output ",
     "css-minify": "npm run css-minify-bash -- dist/css/adminlte.min.css dist/css/adminlte.css",
     "css-minify-splits": "npm-run-all --sequential css-minify:core css-minify:components css-minify:extra-components css-minify:pages css-minify:plugins",


### PR DESCRIPTION
I have to say, that was a nice bug 😁

So, basically, the split dist CSS files were not using proper CSS prefixes all this time.