### PR TITLE
Rename `install` script to `postinstall`

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "docs-compile": "cd docs/ && bundle exec jekyll build -d ../docs_html",
     "docs-serve": "cd docs/ && bundle exec jekyll serve",
     "docs-prepare": "node build/npm/DocsPublish.js -v",
-    "install": "npm run plugins",
+    "postinstall": "npm run plugins",
     "js": "npm-run-all --sequential js-compile js-minify",
     "js-compile": "rollup --config build/config/rollup.config.js --sourcemap",
     "js-minify": "terser --compress typeofs=false --mangle --comments \"/^!/\" --source-map \"content=dist/js/adminlte.js.map,includeSources,url=adminlte.min.js.map\" --output dist/js/adminlte.min.js dist/js/adminlte.js",


### PR DESCRIPTION
Fixes #2722