### PR TITLE
CSS sidebar classes to handle long text

### DIFF
--- a/dist/css/adminlte.css
+++ b/dist/css/adminlte.css
@@ -12846,6 +12846,20 @@ body.sidebar-collapse:not(.sidebar-mini-md):not(.sidebar-mini) .main-header::bef
   content: '\00a0';
 }
 
+.sidebar-mini .nav-sidebar .nav-link,
+.sidebar-mini.sidebar-collapse .main-sidebar:hover .nav-sidebar .nav-link  {
+  white-space: normal !important;
+}
+
+  .sidebar-mini .nav-sidebar .nav-link p,
+  .sidebar-mini.sidebar-collapse .main-sidebar:hover .nav-sidebar .nav-link p {
+      display: inline !important;
+  }
+
+.sidebar-mini.sidebar-collapse .nav-sidebar .nav-link {
+  white-space: nowrap !important;
+}
+
 @media (min-width: 992px) {
   .sidebar-mini .nav-sidebar,
   .sidebar-mini .nav-sidebar > .nav-header,
@@ -12877,7 +12891,7 @@ body.sidebar-collapse:not(.sidebar-mini-md):not(.sidebar-mini) .main-header::bef
     animation-duration: 0.3s;
     -webkit-animation-fill-mode: both;
     animation-fill-mode: both;
-    visibility: hidden;
+    visibility: hidden !important;
   }
   .sidebar-mini.sidebar-collapse .logo-xl {
     -webkit-animation-name: fadeOut;
@@ -12935,7 +12949,7 @@ body.sidebar-collapse:not(.sidebar-mini-md):not(.sidebar-mini) .main-header::bef
     animation-duration: 0.3s;
     -webkit-animation-fill-mode: both;
     animation-fill-mode: both;
-    visibility: visible;
+    visibility: visible !important;
   }
   .sidebar-mini.sidebar-collapse .main-sidebar:hover .logo-xs, .sidebar-mini.sidebar-collapse .main-sidebar.sidebar-focused .logo-xs {
     -webkit-animation-name: fadeOut;

--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
   <!-- JQVMap -->
   <link rel="stylesheet" href="plugins/jqvmap/jqvmap.min.css">
   <!-- Theme style -->
-  <link rel="stylesheet" href="dist/css/adminlte.min.css">
+  <link rel="stylesheet" href="dist/css/adminlte.css">
   <!-- overlayScrollbars -->
   <link rel="stylesheet" href="plugins/overlayScrollbars/css/OverlayScrollbars.min.css">
   <!-- Daterange picker -->
@@ -681,6 +681,23 @@
               <i class="fas fa-circle nav-icon"></i>
               <p>Level 1</p>
             </a>
+          </li>
+          <li class="nav-item has-treeview">
+            <a href="#" class="nav-link">
+              <i class="nav-icon fas fa-circle"></i>
+              <p>
+                Very Very Long Text In Menu Item Show 2 Lines - Level 1
+                <i class="right fas fa-angle-left"></i>
+              </p>
+            </a>
+            <ul class="nav nav-treeview">
+              <li class="nav-item">
+                <a href="#" class="nav-link">
+                  <i class="far fa-circle nav-icon"></i>
+                  <p>Very Very Long Text In Menu Item Show 2 Lines - Level 2</p>
+                </a>
+              </li>
+            </ul>
           </li>
           <li class="nav-header">LABELS</li>
           <li class="nav-item">


### PR DESCRIPTION
Hi!
This is my first time trying to "fork" a project on GitHub. I hope I did it right.

In this branch, I modified the adminlte.css file a little bit to address a problem I was facing when the text in the left side bar menu was too long. My users did not like to scroll left/right so this solution worked for me to wrap it in two or more lines. 

Hope it helps.

**Before:**
![image](https://user-images.githubusercontent.com/12176398/83906182-c49a3080-a76b-11ea-93a8-9ac5d8b3c663.png)

**After:**
![image](https://user-images.githubusercontent.com/12176398/83906114-a2081780-a76b-11ea-8f48-0e2e849e6777.png)

