### PR TITLE
Update browserslist config

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,13 +1,11 @@
 # https://github.com/browserslist/browserslist#readme
 
->= 1%
-last 1 major version
+>= 0.2%
+last 2 major versions
 not dead
 Chrome >= 45
 Firefox >= 38
-Edge >= 12
+Edge >= 15
 Explorer >= 10
 iOS >= 9
 Safari >= 9
-Android >= 4.4
-Opera >= 30

--- a/docs/browser-support.md
+++ b/docs/browser-support.md
@@ -10,19 +10,18 @@ AdminLTE comes with the same browser support as Bootstrap 4.
 >
 > For more details [look here](https://getbootstrap.com/docs/4.4/getting-started/browsers-devices/#supported-browsers).
 
-You can find our supported range of browsers and their versions in [our .browserslistrc file](https://github.com/ColorlibHQ/AdminLTE/blob/v3-dev/.browserslistrc):
+You can find our supported range of browsers and their versions in [our .browserslistrc file](https://github.com/ColorlibHQ/AdminLTE/blob/master/.browserslistrc):
+
 ```
 # https://github.com/browserslist/browserslist#readme
 
->= 1%
-last 1 major version
+>= 0.2%
+last 2 major versions
 not dead
 Chrome >= 45
 Firefox >= 38
-Edge >= 12
+Edge >= 15
 Explorer >= 10
 iOS >= 9
 Safari >= 9
-Android >= 4.4
-Opera >= 30
 ```


### PR DESCRIPTION
* use the defaults
* drop Edge < 15
* drop Android since newer Android uses Android WebView which is Chromium-based

This is under discussion of course, but supporting so old browsers (which are dead BTW) makes no sense. We keep them upstream because we have a stricter policy, but maybe this doesn't apply to your case.

**master**:

```
C:\Users\xmr\Desktop\AdminLTE-or>npx autoprefixer --info
Browsers:
  Chrome for Android: 81
  Firefox for Android: 68
  And_qq: 10.4
  UC for Android: 12.12
  Android: 81, 4.4.3-4.4.4, 4.4
  Baidu: 7.12
  Chrome: 83, 81, 80, 79, 78, 77, 76, 75, 74, 73, 72, 71, 70, 69, 68, 67, 66, 65, 64, 63, 62, 61, 60, 59, 58, 57, 56, 55, 54, 53, 52, 51, 50, 49, 48, 47, 46, 45
  Edge: 83, 81, 80, 79, 18, 17, 16, 15, 14, 13, 12
  Firefox: 76, 75, 74, 73, 72, 71, 70, 69, 68, 67, 66, 65, 64, 63, 62, 61, 60, 59, 58, 57, 56, 55, 54, 53, 52, 51, 50, 49, 48, 47, 46, 45, 44, 43, 42, 41, 40, 39, 38
  IE: 11, 10
  iOS: 13.4-13.5, 13.3, 13.2, 13.0-13.1, 12.2-12.4, 12.0-12.1, 11.3-11.4, 11.0-11.2, 10.3, 10.0-10.2, 9.3, 9.0-9.2
  Kaios: 2.5
  Opera Mini: all
  Opera Mobile: 46
  Opera: 68, 67, 66, 65, 64, 63, 62, 60, 58, 57, 56, 55, 54, 53, 52, 51, 50, 49, 48, 47, 46, 45, 44, 43, 42, 41, 40, 39, 38, 37, 36, 35, 34, 33, 32, 31, 30
  Safari: 13.1, 13, 12.1, 12, 11.1, 11, 10.1, 10, 9.1, 9
  Samsung: 11.1-11.2

These browsers account for 96.46% of all users globally
```

**This branch**:

```
C:\Users\xmr\Desktop\AdminLTE-or>npx autoprefixer --info
Browsers:
  Chrome for Android: 81
  Firefox for Android: 68
  And_qq: 10.4
  UC for Android: 12.12
  Android: 81
  Baidu: 7.12
  Chrome: 83, 81, 80, 79, 78, 77, 76, 75, 74, 73, 72, 71, 70, 69, 68, 67, 66, 65, 64, 63, 62, 61, 60, 59, 58, 57, 56, 55, 54, 53, 52, 51, 50, 49, 48, 47, 46, 45
  Edge: 83, 81, 80, 79, 18, 17, 16, 15
  Firefox: 76, 75, 74, 73, 72, 71, 70, 69, 68, 67, 66, 65, 64, 63, 62, 61, 60, 59, 58, 57, 56, 55, 54, 53, 52, 51, 50, 49, 48, 47, 46, 45, 44, 43, 42, 41, 40, 39, 38
  IE: 11, 10
  iOS: 13.4-13.5, 13.3, 13.2, 13.0-13.1, 12.2-12.4, 12.0-12.1, 11.3-11.4, 11.0-11.2, 10.3, 10.0-10.2, 9.3, 9.0-9.2
  Kaios: 2.5
  Opera Mini: all
  Opera Mobile: 46
  Opera: 68, 67
  Safari: 13.1, 13, 12.1, 12, 11.1, 11, 10.1, 10, 9.1, 9
  Samsung: 11.1-11.2, 10.1

These browsers account for 96.28% of all users globally
```