### PR TITLE
fix: ignore warnings for bg-gradient-variant deprecation and add TODO for removing dependencies

### DIFF
--- a/build/scss/mixins/_backgrounds.scss
+++ b/build/scss/mixins/_backgrounds.scss
@@ -33,7 +33,9 @@
 // Background Gradient Variant
 @mixin background-gradient-variant($name, $color) {
   .bg-gradient-#{$name} {
-    @include bg-gradient-variant("&", $color);
+    // Ignore warning for Bootstrap 4 deprecation
+    // TODO: remove bg-gradient-variant dependencies
+    @include bg-gradient-variant("&", $color, true);
     color: color-yiq($color);
 
     &.btn {
@@ -46,7 +48,9 @@
       }
 
       &:hover {
-        @include bg-gradient-variant("&", darken($color, 7.5%));
+        // Ignore warning for Bootstrap 4 deprecation
+        // TODO: remove bg-gradient-variant dependencies
+        @include bg-gradient-variant("&", darken($color, 7.5%), true);
         border-color: darken($color, 10%);
         color: darken(color-yiq($color), 7.5%);
       }
@@ -55,7 +59,9 @@
       &:not(:disabled):not(.disabled).active,
       &:active,
       &.active {
-        @include bg-gradient-variant("&", darken($color, 10%));
+        // Ignore warning for Bootstrap 4 deprecation
+        // TODO: remove bg-gradient-variant dependencies
+        @include bg-gradient-variant("&", darken($color, 10%), true);
         border-color: darken($color, 12.5%);
         color: color-yiq(darken($color, 10%));
       }


### PR DESCRIPTION
Fixes #2786. This is just a temporary fix to ignore the warnings and add reminders to remove the dependencies.