### PR TITLE
Small fix for TodoList plugin

### DIFF
--- a/build/js/TodoList.js
+++ b/build/js/TodoList.js
@@ -64,7 +64,7 @@ class TodoList {
   // Private
 
   _init() {
-    const $toggleSelector = $(SELECTOR_DATA_TOGGLE)
+    const $toggleSelector = this._element
 
     $toggleSelector.find('input:checkbox:checked').parents('li').toggleClass(CLASS_NAME_TODO_LIST_DONE)
     $toggleSelector.on('change', 'input:checkbox', event => {
@@ -77,15 +77,18 @@ class TodoList {
   static _jQueryInterface(config) {
     return this.each(function () {
       let data = $(this).data(DATA_KEY)
-      const _options = $.extend({}, Default, $(this).data())
 
       if (!data) {
-        data = new TodoList($(this), _options)
-        $(this).data(DATA_KEY, data)
+        data = $(this).data()
       }
 
+      const _options = $.extend({}, Default, typeof config === 'object' ? config : data)
+      const plugin = new TodoList($(this), _options)
+
+      $(this).data(DATA_KEY, typeof config === 'object' ? config : data)
+
       if (config === 'init') {
-        data[config]()
+        plugin[config]()
       }
     })
   }


### PR DESCRIPTION
This was addressed in issue #2997 

This PR fixes on the issue by properly attaching the event listener (from $(SELECTOR_DATA_TOGGLE) to this._element) and fix on the options passed on in the JQuery API. This will then allow the element to have an event listener when the element does not have the data-widget set.

However, a new bug comes from this fix when both Data API and JQuery API is set which will cause the event listener be triggered twice. So users will have to only use either one of the Data or JQuery API and not both at the same time.