### PR TITLE
Support SVG Font Awesome icon in main sidebar

### DIFF
--- a/build/scss/_main-sidebar.scss
+++ b/build/scss/_main-sidebar.scss
@@ -105,6 +105,7 @@
   .menu-open,
   .menu-is-opening {
     > .nav-link {
+      svg.right,
       i.right {
         @include rotate(-90deg);
       }


### PR DESCRIPTION
This commits adds support for SVG Font Awesome icon within the main sidebar. Font Awesome translate i tags to svg tags, resulting in the angle icon not rotating in the sidebar.

Fixes #3532