### PR TITLE
add errorhandling to cardrefresh plugin

### DIFF
--- a/.bundlewatch.config.json
+++ b/.bundlewatch.config.json
@@ -58,7 +58,7 @@
     },
     {
       "path": "./dist/js/adminlte.js",
-      "maxSize": "15.7 kB"
+      "maxSize": "16.1 kB"
     },
     {
       "path": "./dist/js/adminlte.min.js",

--- a/build/js/CardRefresh.js
+++ b/build/js/CardRefresh.js
@@ -36,6 +36,7 @@ const Default = {
   loadOnInit: true,
   responseType: '',
   overlayTemplate: '<div class="overlay"><i class="fas fa-2x fa-sync-alt fa-spin"></i></div>',
+  errorTemplate: '<span class="text-danger"></span>',
   onLoadStart() {},
   onLoadDone(response) {
     return response
@@ -76,6 +77,9 @@ class CardRefresh {
       this._removeOverlay()
     }, this._settings.responseType !== '' && this._settings.responseType).fail((jqXHR, textStatus, errorThrown) => {
       this._removeOverlay()
+      let msg = $(this.__settings.errorTemplate).text(errorThrown)
+      this._parent.find(this._settings.content).empty().append(msg)
+      
       this._settings.onLoadFail.call($(this), jqXHR, textStatus, errorThrown)
     })
 

--- a/build/js/CardRefresh.js
+++ b/build/js/CardRefresh.js
@@ -34,6 +34,7 @@ const Default = {
   content: '.card-body',
   loadInContent: true,
   loadOnInit: true,
+  loadErrorTemplate: true,
   responseType: '',
   overlayTemplate: '<div class="overlay"><i class="fas fa-2x fa-sync-alt fa-spin"></i></div>',
   errorTemplate: '<span class="text-danger"></span>',
@@ -78,8 +79,11 @@ class CardRefresh {
     }, this._settings.responseType !== '' && this._settings.responseType)
     .fail((jqXHR, textStatus, errorThrown) => {
       this._removeOverlay()
-      const msg = $(this._settings.errorTemplate).text(errorThrown)
-      this._parent.find(this._settings.content).empty().append(msg)
+
+      if (this._settings.loadErrorTemplate) {
+        const msg = $(this._settings.errorTemplate).text(errorThrown)
+        this._parent.find(this._settings.content).empty().append(msg)
+      }
 
       this._settings.onLoadFail.call($(this), jqXHR, textStatus, errorThrown)
     })

--- a/build/js/CardRefresh.js
+++ b/build/js/CardRefresh.js
@@ -75,9 +75,10 @@ class CardRefresh {
 
       this._settings.onLoadDone.call($(this), response)
       this._removeOverlay()
-    }, this._settings.responseType !== '' && this._settings.responseType).fail((jqXHR, textStatus, errorThrown) => {
+    }, this._settings.responseType !== '' && this._settings.responseType)
+    .fail((jqXHR, textStatus, errorThrown) => {
       this._removeOverlay()
-      const msg = $(this.__settings.errorTemplate).text(errorThrown)
+      const msg = $(this._settings.errorTemplate).text(errorThrown)
       this._parent.find(this._settings.content).empty().append(msg)
 
       this._settings.onLoadFail.call($(this), jqXHR, textStatus, errorThrown)

--- a/build/js/CardRefresh.js
+++ b/build/js/CardRefresh.js
@@ -39,7 +39,8 @@ const Default = {
   onLoadStart() {},
   onLoadDone(response) {
     return response
-  }
+  },
+  onLoadFail(jqXHR, textStatus, errorThrown) {}
 }
 
 class CardRefresh {
@@ -73,7 +74,10 @@ class CardRefresh {
 
       this._settings.onLoadDone.call($(this), response)
       this._removeOverlay()
-    }, this._settings.responseType !== '' && this._settings.responseType)
+    }, this._settings.responseType !== '' && this._settings.responseType).fail((jqXHR, textStatus, errorThrown) => {
+      this._removeOverlay();
+      this._settings.onLoadFail.call($(this), jqXHR, textStatus, errorThrown);
+    });
 
     $(this._element).trigger($.Event(EVENT_LOADED))
   }

--- a/build/js/CardRefresh.js
+++ b/build/js/CardRefresh.js
@@ -40,7 +40,7 @@ const Default = {
   onLoadDone(response) {
     return response
   },
-  onLoadFail(jqXHR, textStatus, errorThrown) {}
+  onLoadFail(_jqXHR, _textStatus, _errorThrown) {}
 }
 
 class CardRefresh {
@@ -75,9 +75,9 @@ class CardRefresh {
       this._settings.onLoadDone.call($(this), response)
       this._removeOverlay()
     }, this._settings.responseType !== '' && this._settings.responseType).fail((jqXHR, textStatus, errorThrown) => {
-      this._removeOverlay();
-      this._settings.onLoadFail.call($(this), jqXHR, textStatus, errorThrown);
-    });
+      this._removeOverlay()
+      this._settings.onLoadFail.call($(this), jqXHR, textStatus, errorThrown)
+    })
 
     $(this._element).trigger($.Event(EVENT_LOADED))
   }

--- a/build/js/CardRefresh.js
+++ b/build/js/CardRefresh.js
@@ -77,9 +77,9 @@ class CardRefresh {
       this._removeOverlay()
     }, this._settings.responseType !== '' && this._settings.responseType).fail((jqXHR, textStatus, errorThrown) => {
       this._removeOverlay()
-      let msg = $(this.__settings.errorTemplate).text(errorThrown)
+      const msg = $(this.__settings.errorTemplate).text(errorThrown)
       this._parent.find(this._settings.content).empty().append(msg)
-      
+
       this._settings.onLoadFail.call($(this), jqXHR, textStatus, errorThrown)
     })
 


### PR DESCRIPTION
Currently, if a server error occurs while loading contents in the card-refresh plugin, the overlay just stays and the spinner turns forever. With this change, the overlay will be hidden if an error occurs and there is an error handler function in the settings