### PR TITLE
Fixed dropdown-item overlapping dropdown-menu border in active and hover state

### DIFF
--- a/dist/css/adminlte.css
+++ b/dist/css/adminlte.css
@@ -3459,19 +3459,19 @@ input[type="button"].btn-block {
 }
 
 div.dropdown-menu a.dropdown-item:first-child:hover {
-  border-radius: .25rem .25rem 0 0;
+  border-radius: 0.25em 0.25em 0 0;
 }
 
 div.dropdown-menu a.dropdown-item:first-child:active {
-  border-radius: .25rem .25rem 0 0;
+  border-radius: 0.25em 0.25em 0 0;
 }
 
 div.dropdown-menu a.dropdown-item:last-child:hover {
-  border-radius: 0 0 .25rem .25rem;
+  border-radius: 0 0 0.25em 0.25em;
 }
 
 div.dropdown-menu a.dropdown-item:last-child:active {
-  border-radius: 0 0 .25rem .25rem;
+  border-radius: 0 0 0.25em 0.25em;
 }
 
 .dropdown-menu-left {

--- a/dist/css/adminlte.css
+++ b/dist/css/adminlte.css
@@ -3458,11 +3458,11 @@ input[type="button"].btn-block {
   box-shadow: 0 0.5rem 1rem rgba(0, 0, 0, 0.175);
 }
 
-.dropdown-menu a.dropdown-item:first-child:hover, .dropdown-menu a.dropdown-item:first-child:active {
+.dropdown-menu > .dropdown-item:first-child:hover, .dropdown-menu > .dropdown-item:first-child:active {
   border-radius: 0.25em 0.25em 0 0;
 }
 
-.dropdown-menu a.dropdown-item:last-child:hover, .dropdown-menu a.dropdown-item:last-child:active {
+.dropdown-menu > .dropdown-item:last-child:hover, .dropdown-menu > .dropdown-item:last-child:active {
   border-radius: 0 0 0.25em 0.25em;
 }
 

--- a/dist/css/adminlte.css
+++ b/dist/css/adminlte.css
@@ -3458,6 +3458,22 @@ input[type="button"].btn-block {
   box-shadow: 0 0.5rem 1rem rgba(0, 0, 0, 0.175);
 }
 
+div.dropdown-menu a.dropdown-item:first-child:hover {
+  border-radius: .25rem .25rem 0 0;
+}
+
+div.dropdown-menu a.dropdown-item:first-child:active {
+  border-radius: .25rem .25rem 0 0;
+}
+
+div.dropdown-menu a.dropdown-item:last-child:hover {
+  border-radius: 0 0 .25rem .25rem;
+}
+
+div.dropdown-menu a.dropdown-item:last-child:active {
+  border-radius: 0 0 .25rem .25rem;
+}
+
 .dropdown-menu-left {
   right: auto;
   left: 0;

--- a/dist/css/adminlte.css
+++ b/dist/css/adminlte.css
@@ -3458,19 +3458,11 @@ input[type="button"].btn-block {
   box-shadow: 0 0.5rem 1rem rgba(0, 0, 0, 0.175);
 }
 
-div.dropdown-menu a.dropdown-item:first-child:hover {
+.dropdown-menu a.dropdown-item:first-child:hover, .dropdown-menu a.dropdown-item:first-child:active {
   border-radius: 0.25em 0.25em 0 0;
 }
 
-div.dropdown-menu a.dropdown-item:first-child:active {
-  border-radius: 0.25em 0.25em 0 0;
-}
-
-div.dropdown-menu a.dropdown-item:last-child:hover {
-  border-radius: 0 0 0.25em 0.25em;
-}
-
-div.dropdown-menu a.dropdown-item:last-child:active {
+.dropdown-menu a.dropdown-item:last-child:hover, .dropdown-menu a.dropdown-item:last-child:active {
   border-radius: 0 0 0.25em 0.25em;
 }
 


### PR DESCRIPTION
Fixed dropdown-item overlapping dropdown-menu border in active and hover state

Dropdown-item overlapped the dropdown-menu when the state active and hover are used on the dropdown-item.
the border-radius is added for the first and last dropdown-item so the round edges looks awesome.

**From:**
Hover state & Active state
![image](https://user-images.githubusercontent.com/9322930/114247653-e66cd100-9995-11eb-909b-4ea45c201521.png)


**To:**
Hover state & Active state
![image](https://user-images.githubusercontent.com/9322930/114247575-b4f40580-9995-11eb-8c0f-d3d134754f11.png)

