### PR TITLE
Show sidebar search when hover/focus in the sidebar mini

### DIFF
--- a/build/scss/_sidebar-mini.scss
+++ b/build/scss/_sidebar-mini.scss
@@ -247,6 +247,12 @@
   &.sidebar-mini-md,
   &.sidebar-mini-xs {
     .main-sidebar {
+
+      // Hide the sidebar search results when mini mode is active.
+      .sidebar-search-results {
+        display: none;
+      }
+
       .nav-sidebar {
         .nav-link {
           width: $sidebar-mini-width - $sidebar-padding-x * 2;
@@ -277,6 +283,19 @@
         }
         .nav-header {
           display: inline-block;
+        }
+
+        // Show sidebar search when hover/focus on the sidebar mini mode.
+        &:not(.sidebar-no-expand) {
+          .form-control-sidebar {
+            display: inline-block;
+          }
+          .form-control-sidebar ~ .input-group-append {
+            display: flex;
+          }
+          .sidebar-search-open .sidebar-search-results {
+            display: inline-block;
+          }
         }
 
         .nav-child-indent {


### PR DESCRIPTION
Fix to show the **sidebar search** when focus/hover on the sidebar mini (and not using `.sidebar-no-expand` class). Also, the sidebar search results will be hidden when **sidebar mini** is in the collapsed mode.

These bug are related to issue #3597 

I suggest to give it a review since this is my first contribution here and I'm not familiarized with the source code structure.