### PR TITLE
Use docker to run the development enviroment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.git
+*Dockerfile*
+*docker-compose*
+node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM node:14
+
+WORKDIR /code
+
+COPY package.json /code/package.json
+COPY package-lock.json /code/package-lock.json
+
+RUN npm install
+
+COPY . /code
+
+CMD ["npm", "run", "dev"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+version: "3"
+services:
+  admin:
+    build: .
+    command: npm run dev
+    ports:
+      - 3000:3000
+      - 3001:3001
+    volumes:
+    - .:/code
+    - /code/node_modules

--- a/package.json
+++ b/package.json
@@ -39,8 +39,8 @@
     "plugins": "node build/npm/Publish.js -v",
     "sync": "browser-sync start --server --files *.html pages/ dist/",
     "watch": "concurrently \"npm run watch-css\" \"npm run watch-js\"",
-    "watch-css": "nodemon --watch build/scss -e scss -x \"npm-run-all css-lint css\"",
-    "watch-js": "nodemon --watch build/js -e js -x \"npm-run-all js-lint js\""
+    "watch-css": "nodemon --legacy-watch --watch build/scss -e scss -x \"npm-run-all css-lint css\"",
+    "watch-js": "nodemon --legacy-watch --watch build/js -e js -x \"npm-run-all js-lint js\""
   },
   "keywords": [
     "css",


### PR DESCRIPTION
In order to create an isolated environment to work on this code, I create some docker-related files (Dockerfile, .dockerignore and docker-compose) to easily set up a contributor environment just running `docker-compose up`

It's based on node 14 LTS version, publishing the 3000 and 3001 ports to the host machine.

We can consider a middle point between just raw install over the machine the repo or run on Gitpod. The main differences are:

- against raw installation:
  - Isolated environment with a standard node LTS engine
  - Just one step to run the development environment
- against Gitpod:
  - Freedom to choose the IDE/editor of your preference

