### PR TITLE
Fix overflow style on info-box-content class.

### DIFF
--- a/build/scss/_info-box.scss
+++ b/build/scss/_info-box.scss
@@ -48,6 +48,7 @@
     line-height: 1.8;
     flex: 1;
     padding: 0 10px;
+    overflow: hidden;
   }
 
   .info-box-number {


### PR DESCRIPTION
Currently, if the tittle or description of an `info-box` widget is too long, there is an overflow issue, as shown on next image:

![info-box-overflow](https://user-images.githubusercontent.com/63609705/118344927-7bb83380-b507-11eb-89f2-9f65c0b53b01.png)

This PR fix that issue adding the `overflow:hidden` property to the `info-box-content` class to solve that issue, as shown on next image:

![info-box-no-overflow](https://user-images.githubusercontent.com/63609705/118344926-7b1f9d00-b507-11eb-91e2-d519bf260886.png)

However, note that ellipsis are used when text overflows, mainly because inner elements have the `text-overflow: ellipsis;`  and `white-space: nowrap;` properties, as shown next:

```css
.progress-description,
.info-box-text {
    display: block;
    overflow: hidden;
    text-overflow: ellipsis;
    white-space: nowrap;
}
```

We can also remove those properties, to get a long description or title spawn over multiple lines, but I'm not sure if that one is the desired effect. Check next image for an example:

![info-box-wrap](https://user-images.githubusercontent.com/63609705/118345084-9c34bd80-b508-11eb-85ec-e2aa28902d88.png)
