### PR TITLE
Fix disabled style for some buttons.

### DIFF
--- a/build/scss/_buttons.scss
+++ b/build/scss/_buttons.scss
@@ -58,7 +58,6 @@
   &:disabled {
     color: $button-default-color;
     background-color: $button-default-background-color;
-    border-color: $button-default-border-color;
   }
 }
 

--- a/build/scss/_buttons.scss
+++ b/build/scss/_buttons.scss
@@ -53,6 +53,13 @@
     background-color: darken($button-default-background-color, 5%);
     color: darken($button-default-color, 10%);
   }
+
+  &.disabled,
+  &:disabled {
+    color: $button-default-color;
+    background-color: $button-default-background-color;
+    border-color: $button-default-border-color;
+  }
 }
 
 // Application buttons

--- a/build/scss/mixins/_backgrounds.scss
+++ b/build/scss/mixins/_backgrounds.scss
@@ -62,6 +62,7 @@
       &.disabled {
         background-image: none !important;
         border-color: $color;
+        color: color-yiq($color);
       }
     }
   }

--- a/build/scss/mixins/_backgrounds.scss
+++ b/build/scss/mixins/_backgrounds.scss
@@ -37,8 +37,6 @@
     color: color-yiq($color);
 
     &.btn {
-      &.disabled,
-      &:disabled,
       &:not(:disabled):not(.disabled):active,
       &:not(:disabled):not(.disabled).active,
       .show > &.dropdown-toggle {
@@ -58,6 +56,13 @@
         background: $color linear-gradient(180deg, mix($body-bg, darken($color, 10%), 15%), darken($color, 10%)) repeat-x !important;
         border-color: darken($color, 12.5%);
         color: color-yiq(darken($color, 10%));
+      }
+
+      &:disabled,
+      &.disabled {
+        background: $color linear-gradient(180deg, mix($body-bg, $color, 15%), $color) repeat-x !important;
+        background-image: none !important;
+        color: color-yiq($color);
       }
     }
   }

--- a/build/scss/mixins/_backgrounds.scss
+++ b/build/scss/mixins/_backgrounds.scss
@@ -60,9 +60,8 @@
 
       &:disabled,
       &.disabled {
-        background: $color linear-gradient(180deg, mix($body-bg, $color, 15%), $color) repeat-x !important;
         background-image: none !important;
-        color: color-yiq($color);
+        border-color: $color;
       }
     }
   }


### PR DESCRIPTION
Currently, when hover on some buttons (`btn-default` or buttons with `bg-gradient-*` classes) the hover effect is enabled. Those effects are not enabled for the other buttons (`btn-primary`, `btn-info`, etc.). Check next videos for an example:

**Hover effect on `.btn-default`**:

https://user-images.githubusercontent.com/63609705/118375333-75719800-b597-11eb-9324-0e9410fba0b1.mp4

**Hover effect on `.btn.bg-gradient-*`**:

https://user-images.githubusercontent.com/63609705/118375330-71de1100-b597-11eb-86c2-057664bf279e.mp4

This PR removes the hover effect from the mentioned buttons to match the behaviour present for most of the buttons. Check next videos for the result of applying this PR:

**NO hover effect on `.btn-default`**:

https://user-images.githubusercontent.com/63609705/118375332-730f3e00-b597-11eb-988c-c0e63133da47.mp4

**NO hover effect on `.btn.bg-gradient-*`**:

https://user-images.githubusercontent.com/63609705/118375325-6f7bb700-b597-11eb-8a75-2d9ab7be141b.mp4

Please review, since there may be a better way to fix these issues...