### PR TITLE
Add new light and dark buttons variants to buttons page

### DIFF
--- a/build/scss/_buttons.scss
+++ b/build/scss/_buttons.scss
@@ -55,6 +55,17 @@
   }
 }
 
+.btn-outline-light {
+  color: darken($light, 20%);
+  border-color: darken($light, 20%);
+
+  &.disabled,
+  &:disabled {
+    color: darken($light, 20%);
+    border-color: darken($light, 20%);
+  }
+}
+
 // Application buttons
 .btn-app {
   @include border-radius(3px);
@@ -142,13 +153,21 @@
 
   @each $color, $value in $theme-colors-alt {
     .btn-#{$color} {
-      @include button-variant($value, $value);
+      @if $color == dark {
+        @include button-variant(darken($value, 5%), lighten($value, 10%));
+      } @else {
+        @include button-variant($value, $value);
+      }
     }
   }
 
   @each $color, $value in $theme-colors-alt {
     .btn-outline-#{$color} {
-      @include button-outline-variant($value);
+      @if $color == dark {
+        @include button-outline-variant(darken($value, 20%));
+      } @else {
+        @include button-outline-variant($value);
+      }
     }
   }
 }

--- a/pages/UI/buttons.html
+++ b/pages/UI/buttons.html
@@ -1009,6 +1009,46 @@
                       <button type="button" class="btn btn-block btn-warning disabled">Warning</button>
                     </td>
                   </tr>
+                  <tr>
+                    <td>
+                      <button type="button" class="btn btn-block btn-light">Light</button>
+                    </td>
+                    <td>
+                      <button type="button" class="btn btn-block btn-light btn-lg">Light</button>
+                    </td>
+                    <td>
+                      <button type="button" class="btn btn-block btn-light btn-sm">Light</button>
+                    </td>
+                    <td>
+                      <button type="button" class="btn btn-block btn-light btn-xs">Light</button>
+                    </td>
+                    <td>
+                      <button type="button" class="btn btn-block btn-light btn-flat">Light</button>
+                    </td>
+                    <td>
+                      <button type="button" class="btn btn-block btn-light disabled">Light</button>
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>
+                      <button type="button" class="btn btn-block btn-dark">Dark</button>
+                    </td>
+                    <td>
+                      <button type="button" class="btn btn-block btn-dark btn-lg">Dark</button>
+                    </td>
+                    <td>
+                      <button type="button" class="btn btn-block btn-dark btn-sm">Dark</button>
+                    </td>
+                    <td>
+                      <button type="button" class="btn btn-block btn-dark btn-xs">Dark</button>
+                    </td>
+                    <td>
+                      <button type="button" class="btn btn-block btn-dark btn-flat">Dark</button>
+                    </td>
+                    <td>
+                      <button type="button" class="btn btn-block btn-dark disabled">Dark</button>
+                    </td>
+                  </tr>
                 </table>
               </div>
               <!-- /.card -->
@@ -1156,6 +1196,46 @@
                     </td>
                     <td>
                       <button type="button" class="btn btn-block btn-outline-warning disabled">Warning</button>
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>
+                      <button type="button" class="btn btn-block btn-outline-light">Light</button>
+                    </td>
+                    <td>
+                      <button type="button" class="btn btn-block btn-outline-light btn-lg">Light</button>
+                    </td>
+                    <td>
+                      <button type="button" class="btn btn-block btn-outline-light btn-sm">Light</button>
+                    </td>
+                    <td>
+                      <button type="button" class="btn btn-block btn-outline-light btn-xs">Light</button>
+                    </td>
+                    <td>
+                      <button type="button" class="btn btn-block btn-outline-light btn-flat">Light</button>
+                    </td>
+                    <td>
+                      <button type="button" class="btn btn-block btn-outline-light disabled">Light</button>
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>
+                      <button type="button" class="btn btn-block btn-outline-dark">Dark</button>
+                    </td>
+                    <td>
+                      <button type="button" class="btn btn-block btn-outline-dark btn-lg">Dark</button>
+                    </td>
+                    <td>
+                      <button type="button" class="btn btn-block btn-outline-dark btn-sm">Dark</button>
+                    </td>
+                    <td>
+                      <button type="button" class="btn btn-block btn-outline-dark btn-xs">Dark</button>
+                    </td>
+                    <td>
+                      <button type="button" class="btn btn-block btn-outline-dark btn-flat">Dark</button>
+                    </td>
+                    <td>
+                      <button type="button" class="btn btn-block btn-outline-dark disabled">Dark</button>
                     </td>
                   </tr>
                 </table>


### PR DESCRIPTION
This PR adds new rows with `light` and `dark` buttons variants examples to the `pages/UI/buttons.html` page and make some fixes on their style.

### Without Style Fixes:

Style problem in dark-mode for the `.btn-dark` class:

![dark-mode-dark-problem](https://user-images.githubusercontent.com/63609705/118377091-27ae5d00-b5a2-11eb-96af-9f9f642a051c.png)

Style problem in dark-mode for the `.btn-outline-dark` class:

![outline-dark-mode-dark-problem](https://user-images.githubusercontent.com/63609705/118377090-2715c680-b5a2-11eb-9f94-7cedeb90aa30.png)

Style problem in default mode for the `.btn-outline-light` class:

![outline-light-issue](https://user-images.githubusercontent.com/63609705/118377092-27ae5d00-b5a2-11eb-8390-d286d357a48b.png)

### With Style Fixes:

The new styles for default mode. Note how `.btn-outline-light` is now visible for the user.

![buttons](https://user-images.githubusercontent.com/63609705/118377095-28df8a00-b5a2-11eb-83ca-53f040418857.png)

![buttons-outline](https://user-images.githubusercontent.com/63609705/118377093-2846f380-b5a2-11eb-8a66-0e828eb2706d.png)

The new styles for dark mode. Note how `.btn-dark` and `.btn-outline-dark` are now visible for the user.

![buttons-dark-mode](https://user-images.githubusercontent.com/63609705/118377099-2a10b700-b5a2-11eb-847b-938b69260c4c.png)

![buttons-outline-dark-mode](https://user-images.githubusercontent.com/63609705/118377096-29782080-b5a2-11eb-8fdb-84eab53735e8.png)