### PR TITLE
Fix control sidebar when not using the slide animation

### DIFF
--- a/build/js/ControlSidebar.js
+++ b/build/js/ControlSidebar.js
@@ -97,6 +97,7 @@ class ControlSidebar {
       })
     } else {
       $body.addClass(CLASS_NAME_CONTROL_SIDEBAR_OPEN)
+      $(this._config.target).show()
     }
 
     this._fixHeight()

--- a/index3.html
+++ b/index3.html
@@ -155,7 +155,7 @@
         </a>
       </li>
       <li class="nav-item">
-        <a class="nav-link" data-widget="control-sidebar" data-slide="true" href="#" role="button">
+        <a class="nav-link" data-widget="control-sidebar" data-controlsidebar-slide="false" href="#" role="button">
           <i class="fas fa-th-large"></i>
         </a>
       </li>


### PR DESCRIPTION
This PR includes a fix to the control sidebar when using the `data-controlsidebar-slide="false"` option. Related to issue #3716 

You can see it working on next video:

https://user-images.githubusercontent.com/63609705/119242705-98232400-bb36-11eb-92e4-d7df1fda8eea.mp4

Also `index3.html` demo page was modified to include that option, so it is easy to test on the future.

### Alternative Solution.

Instead of changing the `ControlSidebar.js`, we can change style of `.control-sidebar-open` class in `_control-sidebar.scss` to add `display: block !important` instead of just `display: block`, as shown next:

```scss
// Control sidebar open state
.control-sidebar-open {
  .control-sidebar {
    display: block !important;   /* HERE */

    &,
    &::before {
      right: 0;
    }
  }

  &.control-sidebar-push,
  &.control-sidebar-push-slide {
    .content-wrapper,
    .main-footer {
      margin-right: $control-sidebar-width;
    }
  }
}
```

So, let me know what solution is better...