### PR TITLE
Fix childs behaviour when closing a parent treeview menu

### DIFF
--- a/build/js/Treeview.js
+++ b/build/js/Treeview.js
@@ -80,11 +80,10 @@ class Treeview {
     const collapsedEvent = $.Event(EVENT_COLLAPSED)
 
     parentLi.removeClass(`${CLASS_NAME_IS_OPENING} ${CLASS_NAME_OPEN}`)
-    parentLi.find(SELECTOR_LI).removeClass(`${CLASS_NAME_IS_OPENING} ${CLASS_NAME_OPEN}`)
     treeviewMenu.stop().slideUp(this._config.animationSpeed, () => {
       $(this._element).trigger(collapsedEvent)
       treeviewMenu.find(`${SELECTOR_OPEN} > ${SELECTOR_TREEVIEW_MENU}`).slideUp()
-      treeviewMenu.find(SELECTOR_OPEN).removeClass(CLASS_NAME_OPEN)
+      treeviewMenu.find(SELECTOR_OPEN).removeClass(`${CLASS_NAME_IS_OPENING} ${CLASS_NAME_OPEN}`)
     })
   }
 


### PR DESCRIPTION
The recently pushed PR #3647 tried to solve an icon issue on child menus when closing a parent treeview menu. See issue #3643 for details. However, this introduces a new issue, now child menus are not collapsed when closing a parent treeview menu, see next video:

https://user-images.githubusercontent.com/63609705/121935083-6dd01b00-cd1e-11eb-9972-c01aa1a08f39.mp4

This PR solves the icon issue in a proper way, not introducing the mentioned new issue. Check next the video showing the behaviour when using this PR:

https://user-images.githubusercontent.com/63609705/121935503-e040fb00-cd1e-11eb-8401-006398e4018f.mp4

