### PR TITLE
Update .gitattributes to trim php package size

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,3 +4,22 @@
 # Ignores for analysis is used to produce the language stats bar which displays the languages percentages
 plugins/* linguist-vendored=true
 docs/* linguist-vendored=true
+
+# Add export-ignore to trim php packagist download size
+# See https://php.watch/articles/composer-gitattributes
+.github/                        export-ignore
+docs/                           export-ignore
+.babelrc.js                     export-ignore
+.browserslistrc                 export-ignore
+.bundlewatch.config.json        export-ignore
+.editorconfig                   export-ignore
+.eslintignore                   export-ignore
+.eslintrc.json                  export-ignore
+.gitattributes                  export-ignore
+.gitignore                      export-ignore
+.gitpod.yml                     export-ignore
+.lgtm.yml                       export-ignore
+.npmignore                      export-ignore
+.stylelintignore                export-ignore
+.stylelintrc                    export-ignore
+# ...


### PR DESCRIPTION
first of all, thanks for the awesome package!

currently, when we run `composer require almasaeed2010/adminlte` we get HUGE package size, its about ~107MB.
one solution to reduce the size of php package is to add `.gitattributes` file, see https://php.watch/articles/composer-gitattributes.

this PR update the `.gitattributes` file to save approximately ~27MB of disk space.

feel free to add/remove entry from `.gitattributes` file as i dont really know what is really needed or not in the php package.
but i am sure the current entry i put is not needed.