### PR TITLE
Fix height problem on default tabs for the IFrame plugin

### DIFF
--- a/build/js/IFrame.js
+++ b/build/js/IFrame.js
@@ -227,14 +227,16 @@ class IFrame {
   // Private
 
   _init() {
-    if ($(SELECTOR_TAB_CONTENT).children().length > 2) {
+    const usingDefTab = ($(SELECTOR_TAB_CONTENT).children().length > 2)
+
+    if (usingDefTab) {
       const $el = $(`${SELECTOR_TAB_PANE}:first-child`)
       $el.show()
       this._setItemActive($el.find('iframe').attr('src'))
     }
 
     this._setupListeners()
-    this._fixHeight(true)
+    this._fixHeight(!usingDefTab)
   }
 
   _initFrameElement() {

--- a/build/js/Layout.js
+++ b/build/js/Layout.js
@@ -86,9 +86,9 @@ class Layout {
       if (max === heights.controlSidebar) {
         $contentSelector.css(this._config.panelAutoHeightMode, (max + offset))
       } else if (max === heights.window) {
-        $contentSelector.css(this._config.panelAutoHeightMode, (max + offset) - (heights.footer == 0 ? 0 : (heights.header - heights.footer)))
+        $contentSelector.css(this._config.panelAutoHeightMode, (max + offset) - heights.header - heights.footer)
       } else {
-        $contentSelector.css(this._config.panelAutoHeightMode, (max + offset) - (heights.footer == 0 ? 0 : heights.header))
+        $contentSelector.css(this._config.panelAutoHeightMode, (max + offset) - heights.header)
       }
 
       if (this._isFooterFixed()) {

--- a/docs/javascript/iframe.md
+++ b/docs/javascript/iframe.md
@@ -43,7 +43,9 @@ To get the iframe 100% working you need the following content-wrapper markup:
     <a class="nav-link bg-light" href="#" data-widget="iframe-fullscreen"><i class="fas fa-expand"></i></a>
   </div>
   <div class="tab-content">
-    <div class="tab-pane fade active show" id="panel-index" role="tabpanel" aria-labelledby="tab-index"><iframe src="./index.html" style="height: 671px;"></iframe></div>
+    <div class="tab-pane fade active show" id="panel-index" role="tabpanel" aria-labelledby="tab-index">
+      <iframe src="./index.html"></iframe>
+    </div>
     <div class="tab-empty">
       <h2 class="display-4">No tab selected!</h2>
     </div>


### PR DESCRIPTION
In relation to #3822

- Revert some changes that where introduced on the fix https://github.com/ColorlibHQ/AdminLTE/commit/4a2a28f799146867c6b0717936cb14de082e9792 because they do not solve the intended issue #3822 and introduced some other problems related to the height.

In relation to #3872

- Add a fix to solve height calculation of a default tab on the **IFrame** plugin.
- Change documentation of the **IFrame** plugin, to remove hardcoded height for the default tabs. Height can't be hardcoded because height depends on the client screen.