### PR TITLE
Fix logic to capture links on IFrame mode.

### DIFF
--- a/build/js/IFrame.js
+++ b/build/js/IFrame.js
@@ -259,7 +259,7 @@ class IFrame {
         this._fixHeight()
       }, 1)
     })
-    if ($('body').hasClass(CLASS_NAME_IFRAME_MODE)) {
+    if ($(SELECTOR_CONTENT_WRAPPER).hasClass(CLASS_NAME_IFRAME_MODE)) {
       $(document).on('click', `${SELECTOR_SIDEBAR_MENU_ITEM}, ${SELECTOR_SIDEBAR_SEARCH_ITEM}`, e => {
         e.preventDefault()
         this.openTabSidebar(e.target)


### PR DESCRIPTION
Minor fix on the logic that capture links on the **IFrame** mode. Related to issue #3649