### PR TITLE
Fix card-outline-tabs in dark mode and hover

### DIFF
--- a/build/scss/_cards.scss
+++ b/build/scss/_cards.scss
@@ -504,8 +504,11 @@ html.maximized-card {
     .card-footer {
       background-color: rgba($black, .1);
     }
+    &.card-outline-tabs {
+      border-top: 0;
+    }
     &.card-outline-tabs .card-header a:hover {
-      border-color: $gray-600;
+      border-top-color: $gray-600;
       border-bottom-color: transparent;
     }
     &:not(.card-outline) > .card-header a.active {

--- a/build/scss/mixins/_cards.scss
+++ b/build/scss/mixins/_cards.scss
@@ -24,7 +24,7 @@
     }
 
     &.card-outline-tabs {
-      > .card-header {        
+      > .card-header {
         a:hover{
           border-top: 3px solid $nav-tabs-border-color;
         }

--- a/build/scss/mixins/_cards.scss
+++ b/build/scss/mixins/_cards.scss
@@ -24,15 +24,13 @@
     }
 
     &.card-outline-tabs {
-      > .card-header {
-        a {
-          &:hover {
-            border-top: 3px solid $nav-tabs-border-color;
-          }
-
-          &.active {
-            border-top: 3px solid $color;
-          }
+      > .card-header {        
+        a:hover{
+          border-top: 3px solid $nav-tabs-border-color;
+        }
+        a.active,
+        a.active:hover{
+          border-top: 3px solid $color;
         }
       }
     }


### PR DESCRIPTION
Fix card-outline-tabs in dark mode, which had a line above the header and also in the active tab, and when hovering the mouse in the active tab, the color also changed

![image](https://user-images.githubusercontent.com/40365277/143964238-ae7c7a02-3a02-468d-b785-0c42e1e7937f.png)

after the changes
![image](https://user-images.githubusercontent.com/40365277/143964464-5f8b5803-6059-4157-993c-5ad7ae8fef1e.png)
