### PR TITLE
Fix Bug for encoding URI

### DIFF
--- a/build/js/SidebarSearch.js
+++ b/build/js/SidebarSearch.js
@@ -187,7 +187,7 @@ class SidebarSearch {
     }
 
     const groupItemElement = $('<a/>', {
-      href: link,
+      href: decodeURIComponent(link),
       class: 'list-group-item'
     })
     const searchTitleElement = $('<div/>', {


### PR DESCRIPTION
Encoded URI:
http%3A%2F%2F127.0.0.1%
![scrnli_1_21_2022_6-55-07 PM](https://user-images.githubusercontent.com/10051801/150578269-41896a15-337e-4a35-b3a8-38965e8410e1.png)
3A8001%2F

Decoded URI:
http://127.0.0.1:8001/
![scrnli_1_21_2022_6-55-47 PM](https://user-images.githubusercontent.com/10051801/150578290-4ec0178b-9a82-47fd-8a5a-ee7f4925c3e2.png)

