### PR TITLE
Add verification use of & outside of style rules

### DIFF
--- a/build/scss/mixins/_backgrounds.scss
+++ b/build/scss/mixins/_backgrounds.scss
@@ -4,7 +4,7 @@
 
 // Background Variant
 @mixin background-variant($name, $color) {
-  &.bg-#{$name} {
+  #{if(&, "&.bg-#{$name}",".bg-#{$name}")} {
     background-color: #{$color} !important;
 
     &,


### PR DESCRIPTION
This solves the error when building in Laravel mix. On other hand, this error was already mentioned in #4255. 

See the error:

```bash
SassError: Top-level selectors may not contain the parent selector "&".
   ╷ 
7 │   &.bg-#{$name} {
   │   ^^^^^^^^^^^^^^
   ╵
```

How it was solved:

See documentation: https://sass-lang.com/documentation/style-rules/parent-selector#in-sassscript where says:

`If the & expression is used outside any style rules, it returns null. Since null is [falsey](https://sass-lang.com/documentation/at-rules/control/if#truthiness-and-falsiness), this means you can easily use it to determine whether a mixin is being called in a style rule or not`

I hope that it helps other people. 


