### PR TITLE
Fix: deprecated packages flag-icon-css

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "ekko-lightbox": "^5.3.0",
     "fastclick": "^1.0.6",
     "filterizr": "^2.2.4",
-    "flag-icon-css": "^4.1.7",
+    "flag-icons": "^6.2.0",
     "flot": "^4.2.2",
     "fs-extra": "^10.0.1",
     "fullcalendar": "^5.10.2",

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "ekko-lightbox": "^5.3.0",
     "fastclick": "^1.0.6",
     "filterizr": "^2.2.4",
-    "flag-icons": "^6.2.0",
+    "flag-icons": "^4.1.7",
     "flot": "^4.2.2",
     "fs-extra": "^10.0.1",
     "fullcalendar": "^5.10.2",


### PR DESCRIPTION
Issue : #4394

Rename package **flag-icon-css** to **flag-icons**