### PR TITLE
Fix CardWidget unable to be maximized after it was sorted.

### DIFF
--- a/build/js/CardWidget.js
+++ b/build/js/CardWidget.js
@@ -108,6 +108,7 @@ class CardWidget {
     this._parent.css({
       height: this._parent.height(),
       width: this._parent.width(),
+      position: 'fixed',
       transition: 'all .15s'
     }).delay(150).queue(function () {
       const $element = $(this)


### PR DESCRIPTION
The related issue:  #4479 