### PR TITLE
fix: prevent multiple event listener calls #4339

### DIFF
--- a/build/js/Treeview.js
+++ b/build/js/Treeview.js
@@ -120,6 +120,7 @@ class Treeview {
   _setupListeners() {
     const elementId = this._element.attr('id') !== undefined ? `#${this._element.attr('id')}` : ''
     $(document).on('click', `${elementId}${this._config.trigger}`, event => {
+      event.stopImmediatePropagation()
       this.toggle(event)
     })
   }


### PR DESCRIPTION
in some implementation cases in SPA, the Treeview must be initiated manually, but when the page is refreshed then the Treeview will be initialized more than once and create duplicate event listeners that make the Treeview toggle become buggy (it won't collapse when the Treeview initiated more than once), so I added the stopImmediatePropagation to prevent the multiple event listener calls. 