### PR TITLE
Don't use sidebar-mini in mobile mode

### DIFF
--- a/src/ts/push-menu.ts
+++ b/src/ts/push-menu.ts
@@ -172,6 +172,13 @@ class PushMenu {
   }
 
   toggleMini(): void {
+    if (this._bodyClass.contains(CLASS_NAME_LAYOUT_MOBILE)) {
+      // In mobile mode, the mini sidebar doesn't work well, since it
+      // overlaps with the header. Instead of going mini, just close.
+      this.close()
+      return
+    }
+
     if (this._bodyClass.contains(CLASS_NAME_SIDEBAR_MINI_HAD)) {
       this._bodyClass.remove(CLASS_NAME_SIDEBAR_MINI_HAD)
       this._bodyClass.add(CLASS_NAME_SIDEBAR_MINI)


### PR DESCRIPTION
In mobile mode, the mini sidebar doesn't work well, since it overlaps with the header (it effectively can't be dismissed). 

So instead of going mini, just close.

### Before

https://user-images.githubusercontent.com/129551/193960752-f284b565-8d47-41c1-a2f4-41f91366452e.mov

### After

https://user-images.githubusercontent.com/129551/193960910-d62cf159-8c0c-4356-9880-ecac136090e8.mov

