### PR TITLE
Disable spellcheckers inspection of passwords

### DIFF
--- a/pages/examples/lockscreen.html
+++ b/pages/examples/lockscreen.html
@@ -32,7 +32,7 @@
     <!-- lockscreen credentials (contains the form) -->
     <form class="lockscreen-credentials">
       <div class="input-group">
-        <input type="password" class="form-control" placeholder="password">
+        <input type="password" spellcheck="false" class="form-control" placeholder="password">
 
         <div class="input-group-append">
           <button type="button" class="btn">

--- a/pages/examples/login-v2.html
+++ b/pages/examples/login-v2.html
@@ -34,7 +34,7 @@
           </div>
         </div>
         <div class="input-group mb-3">
-          <input type="password" class="form-control" placeholder="Password">
+          <input type="password" spellcheck="false" class="form-control" placeholder="Password">
           <div class="input-group-append">
             <div class="input-group-text">
               <span class="fas fa-lock"></span>

--- a/pages/examples/login.html
+++ b/pages/examples/login.html
@@ -34,7 +34,7 @@
           </div>
         </div>
         <div class="input-group mb-3">
-          <input type="password" class="form-control" placeholder="Password">
+          <input type="password" spellcheck="false" class="form-control" placeholder="Password">
           <div class="input-group-append">
             <div class="input-group-text">
               <span class="fas fa-lock"></span>

--- a/pages/examples/recover-password-v2.html
+++ b/pages/examples/recover-password-v2.html
@@ -24,7 +24,7 @@
       <p class="login-box-msg">You are only one step a way from your new password, recover your password now.</p>
       <form action="login.html" method="post">
         <div class="input-group mb-3">
-          <input type="password" class="form-control" placeholder="Password">
+          <input type="password" spellcheck="false" class="form-control" placeholder="Password">
           <div class="input-group-append">
             <div class="input-group-text">
               <span class="fas fa-lock"></span>
@@ -32,7 +32,7 @@
           </div>
         </div>
         <div class="input-group mb-3">
-          <input type="password" class="form-control" placeholder="Confirm Password">
+          <input type="password" spellcheck="false" class="form-control" placeholder="Confirm Password">
           <div class="input-group-append">
             <div class="input-group-text">
               <span class="fas fa-lock"></span>

--- a/pages/examples/recover-password.html
+++ b/pages/examples/recover-password.html
@@ -26,7 +26,7 @@
 
       <form action="login.html" method="post">
         <div class="input-group mb-3">
-          <input type="password" class="form-control" placeholder="Password">
+          <input type="password" spellcheck="false" class="form-control" placeholder="Password">
           <div class="input-group-append">
             <div class="input-group-text">
               <span class="fas fa-lock"></span>
@@ -34,7 +34,7 @@
           </div>
         </div>
         <div class="input-group mb-3">
-          <input type="password" class="form-control" placeholder="Confirm Password">
+          <input type="password" spellcheck="false" class="form-control" placeholder="Confirm Password">
           <div class="input-group-append">
             <div class="input-group-text">
               <span class="fas fa-lock"></span>

--- a/pages/examples/register-v2.html
+++ b/pages/examples/register-v2.html
@@ -41,7 +41,7 @@
           </div>
         </div>
         <div class="input-group mb-3">
-          <input type="password" class="form-control" placeholder="Password">
+          <input type="password" spellcheck="false" class="form-control" placeholder="Password">
           <div class="input-group-append">
             <div class="input-group-text">
               <span class="fas fa-lock"></span>
@@ -49,7 +49,7 @@
           </div>
         </div>
         <div class="input-group mb-3">
-          <input type="password" class="form-control" placeholder="Retype password">
+          <input type="password" spellcheck="false" class="form-control" placeholder="Retype password">
           <div class="input-group-append">
             <div class="input-group-text">
               <span class="fas fa-lock"></span>

--- a/pages/examples/register.html
+++ b/pages/examples/register.html
@@ -42,7 +42,7 @@
           </div>
         </div>
         <div class="input-group mb-3">
-          <input type="password" class="form-control" placeholder="Password">
+          <input type="password" spellcheck="false" class="form-control" placeholder="Password">
           <div class="input-group-append">
             <div class="input-group-text">
               <span class="fas fa-lock"></span>
@@ -50,7 +50,7 @@
           </div>
         </div>
         <div class="input-group mb-3">
-          <input type="password" class="form-control" placeholder="Retype password">
+          <input type="password" spellcheck="false" class="form-control" placeholder="Retype password">
           <div class="input-group-append">
             <div class="input-group-text">
               <span class="fas fa-lock"></span>

--- a/pages/forms/advanced.html
+++ b/pages/forms/advanced.html
@@ -1515,7 +1515,7 @@
                       </div>
                       <div class="form-group">
                         <label for="exampleInputPassword1">Password</label>
-                        <input type="password" class="form-control" id="exampleInputPassword1" placeholder="Password">
+                        <input type="password" spellcheck="false" class="form-control" id="exampleInputPassword1" placeholder="Password">
                       </div>
                       <button class="btn btn-primary" onclick="stepper.next()">Next</button>
                     </div>

--- a/pages/forms/general.html
+++ b/pages/forms/general.html
@@ -867,7 +867,7 @@
                   </div>
                   <div class="form-group">
                     <label for="exampleInputPassword1">Password</label>
-                    <input type="password" class="form-control" id="exampleInputPassword1" placeholder="Password">
+                    <input type="password" spellcheck="false" class="form-control" id="exampleInputPassword1" placeholder="Password">
                   </div>
                   <div class="form-group">
                     <label for="exampleInputFile">File input</label>
@@ -1093,7 +1093,7 @@
                   <div class="form-group row">
                     <label for="inputPassword3" class="col-sm-2 col-form-label">Password</label>
                     <div class="col-sm-10">
-                      <input type="password" class="form-control" id="inputPassword3" placeholder="Password">
+                      <input type="password" spellcheck="false" class="form-control" id="inputPassword3" placeholder="Password">
                     </div>
                   </div>
                   <div class="form-group row">

--- a/pages/forms/validation.html
+++ b/pages/forms/validation.html
@@ -867,7 +867,7 @@
                   </div>
                   <div class="form-group">
                     <label for="exampleInputPassword1">Password</label>
-                    <input type="password" name="password" class="form-control" id="exampleInputPassword1" placeholder="Password">
+                    <input type="password" spellcheck="false" name="password" class="form-control" id="exampleInputPassword1" placeholder="Password">
                   </div>
                   <div class="form-group mb-0">
                     <div class="custom-control custom-checkbox">


### PR DESCRIPTION
Prevent [password leakage by spell checkers](https://www.otto-js.com/news/article/chrome-and-edge-enhanced-spellcheck-features-expose-pii-even-your-passwords) by adding an explicit [`spellchack=false` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/spellcheck) to the input fields.