### PR TITLE
Fix a mini sidebar bug when embedding admin-lte into iframe

### DIFF
--- a/build/js/IFrame.js
+++ b/build/js/IFrame.js
@@ -272,7 +272,7 @@ class IFrame {
   }
 
   _initFrameElement() {
-    if (window.frameElement && this._config.autoIframeMode) {
+    if (window.frameElement && this._config?.autoIframeMode) {
       const $body = $('body')
       $body.addClass(CLASS_NAME_IFRAME_MODE)
 


### PR DESCRIPTION
When embedding whole admin-lte page into a iframe, mini sidebar will display without content.
JS error code: `Uncaught TypeError: Cannot read properties of null (reading 'autoIframeMode')`

html iframe code:

```
<html>
    <meta http-equiv="Content-Type" content="text/html;charset=utf-8"/>
    <head>
        <style type="text/css">
            html, body {
                border: 0px;
                margin: 0px;
                padding: 0px;
            }

            #admin-lte{
                height: 480px;
                width: 640px;
            }
        </style>
    </head>
    <body>
        <iframe id="admin-lte" src="index.html" frameborder="0" scrolling="no"></iframe>
    </body>
</html>
```