### PR TITLE
Add EVENT_SHOWN_DONE event trigger

### DIFF
--- a/build/js/PushMenu.js
+++ b/build/js/PushMenu.js
@@ -20,6 +20,7 @@ const JQUERY_NO_CONFLICT = $.fn[NAME]
 const EVENT_COLLAPSED = `collapsed${EVENT_KEY}`
 const EVENT_COLLAPSED_DONE = `collapsed-done${EVENT_KEY}`
 const EVENT_SHOWN = `shown${EVENT_KEY}`
+const EVENT_SHOWN_DONE = `shown-done${EVENT_KEY}`
 
 const SELECTOR_TOGGLE_BUTTON = '[data-widget="pushmenu"]'
 const SELECTOR_BODY = 'body'
@@ -74,6 +75,10 @@ class PushMenu {
     }
 
     $(this._element).trigger($.Event(EVENT_SHOWN))
+    
+    setTimeout(() => {
+      $(this._element).trigger($.Event(EVENT_SHOWN_DONE))
+    }, this._options.animationSpeed)
   }
 
   collapse() {


### PR DESCRIPTION
Adding a new event trigger called `EVENT_SHOWN_DONE` to the code. This trigger will be used to notify when the "show" animation is completed.

The code changes include adding a new constant called EVENT_SHOWN_DONE and setting its value to `shown-done${EVENT_KEY}`. Additionally, a setTimeout function is added to trigger the new event after the "collapse" animation is completed.

This new event trigger will help to notify any interested parties when the "show" animation is completed, which can be useful for tracking user behavior or triggering additional actions.

Please review and consider these changes for inclusion in the project. Thank you.