### PR TITLE
Local Google Fonts

### DIFF
--- a/src/html/components/_head.astro
+++ b/src/html/components/_head.astro
@@ -19,11 +19,11 @@ const cssPath = isRtl ? ".rtl" : "";
 />
 <!--end::Primary Meta Tags-->
 <!--begin::Fonts-->
-<link rel="preconnect" href="https://fonts.googleapis.com" />
-<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 <link
-  href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:ital,wght@0,300;0,400;0,700;1,400&display=swap"
   rel="stylesheet"
+  href="https://cdn.jsdelivr.net/npm/@fontsource/source-sans-3@5.0.12/index.css"
+  integrity="sha256-tXJfXfp6Ewt1ilPzLDtQnJV4hclT9XuaZUKyUvmyr+Q="
+  crossorigin="anonymous"
 />
 <!--end::Fonts-->
 <!--begin::Third Party Plugin(OverlayScrollbars)-->

--- a/src/scss/_bootstrap-variables.scss
+++ b/src/scss/_bootstrap-variables.scss
@@ -607,7 +607,7 @@ $aspect-ratios: (
 
 // scss-docs-start font-variables
 // stylelint-disable value-keyword-case
-$font-family-sans-serif:      "Source Sans Pro", system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", "Noto Sans", "Liberation Sans", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji" !default; // adminlte-modified
+$font-family-sans-serif:      "Source Sans 3", system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", "Noto Sans", "Liberation Sans", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji" !default; // adminlte-modified
 $font-family-monospace:       SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace !default;
 // stylelint-enable value-keyword-case
 $font-family-base:            var(--#{$prefix}font-sans-serif) !default;

--- a/src/scss/adminlte.scss
+++ b/src/scss/adminlte.scss
@@ -60,7 +60,6 @@
 // Bootstrap Utilities
 @import "bootstrap/scss/utilities/api";
 
-
 // AdminLTE Configuration
 // ---------------------------------------------------
 @import "variables";


### PR DESCRIPTION
This was a feature request #5296
I also ran into cases where I had to switch to local Google fonts due to European GDPR laws (loading fonts from Google transfers the user's IP address to Google without his consent).

The currently used font Source Sans Pro has been updated and is now named "Source Sans 3". I downloaded the woff2 files for weights 300, 400 and 700 (normal and italic) in cyrillic, cyrillic-ext, greek, greek-ext, latin, latin-ext and vietnamese versions (as the remote CSS from Google fonts currently provides).

I left the reference to the remote Google fonts in `_head.astro` in case someone wants to use those. However, in that case the user also needs to remove the references to the local font files and re-compile adminlte.css.