### PR TITLE
Update push-menu.ts

### DIFF
--- a/src/ts/push-menu.ts
+++ b/src/ts/push-menu.ts
@@ -156,7 +156,7 @@ onDOMContentLoaded(() => {
     const target = event.currentTarget as HTMLElement
     const data = new PushMenu(target, Defaults)
     data.collapse()
-  })
+  }, { passive: true })
   sidebarOverlay.addEventListener('click', event => {
     event.preventDefault()
     const target = event.currentTarget as HTMLElement


### PR DESCRIPTION
This fixes the error message about the push-menu being a scroll-blocking event by adding passive mode to the event handler.

This resolved the issue #5490
