### PR TITLE
[issue 5612]: Fix 'husky' error when installing admin-lte 3.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "raphael": "^2.3.0",
     "select2": "^4.0.13",
     "sparklines": "^1.3.0",
-    "summernote": "^0.8.20",
+    "summernote": "^0.9.1",
     "sweetalert2": "^11.7.3",
     "tempusdominus-bootstrap-4": "^5.39.2",
     "toastr": "^2.1.4",


### PR DESCRIPTION
Fix #5612 by updating `summernote` to v0.9.1. See [summernote's release notes](https://github.com/summernote/summernote/releases/tag/v0.9.1).