### PR TITLE
Add logic to parse data attributes on treeview plugin

### DIFF
--- a/src/ts/treeview.ts
+++ b/src/ts/treeview.ts
@@ -119,13 +119,24 @@ onDOMContentLoaded(() => {
       const target = event.target as HTMLElement
       const targetItem = target.closest(SELECTOR_NAV_ITEM) as HTMLElement | undefined
       const targetLink = target.closest(SELECTOR_NAV_LINK) as HTMLAnchorElement | undefined
+      const lteToggleElement = event.currentTarget as HTMLElement
 
       if (target?.getAttribute('href') === '#' || targetLink?.getAttribute('href') === '#') {
         event.preventDefault()
       }
 
       if (targetItem) {
-        const data = new Treeview(targetItem, Default)
+        // Read data attributes
+        const accordionAttr = lteToggleElement.dataset.accordion
+        const animationSpeedAttr = lteToggleElement.dataset.animationSpeed
+
+        // Build config from data attributes, fallback to Default
+        const config: Config = {
+          accordion: accordionAttr === undefined ? Default.accordion : accordionAttr === 'true',
+          animationSpeed: animationSpeedAttr === undefined ? Default.animationSpeed : Number(animationSpeedAttr)
+        }
+
+        const data = new Treeview(targetItem, config)
         data.toggle()
       }
     })


### PR DESCRIPTION
Add changes on `src/ts/treeview.ts` file to parse next data attributes in order to configure the **treeview plugin** from `HTML` markup.

- `data-accordion`
- `data-animation-speed` 

The `data-accordion` was already used in the source code, see file `src/html/components/dashboard/_sidenav.astro` at line `35`, but it was never parsed by the plugin:

```html
<ul
  class="nav sidebar-menu flex-column"
  data-lte-toggle="treeview"
  role="menu"
  data-accordion="false"
>
```

As a sidenote, what the status of this package @REJack @danny007in , are you guys still working on it? I'm curious because I'm working on an integration of **AdminLTE v4** for **Laravel** and I need to know what to expect on the future around this package...