### PR TITLE
Improve heading style for sidebar

### DIFF
--- a/src/scss/_app-sidebar.scss
+++ b/src/scss/_app-sidebar.scss
@@ -140,7 +140,10 @@
 
   // Section Heading
   .nav-header {
+    display: inline;
+    overflow: hidden;
     color: var(--#{$lte-prefix}sidebar-header-color);
+    text-overflow: ellipsis;
     background-color: inherit;
   }
 
@@ -225,8 +228,11 @@
   }
 
   .nav-header {
+    position: relative;
+    width: 100%;
     padding: $nav-link-padding-y ($nav-link-padding-y * 1.5);
     font-size: .9rem;
+    @include transition(width $lte-transition-fn $lte-transition-speed);
   }
 
   // Tree view menu
@@ -402,7 +408,7 @@
     max-width: var(--#{$lte-prefix}sidebar-width);
 
     .sidebar-menu .nav-header {
-      display: inline-block;
+      display: inline;
     }
 
     .sidebar-menu .nav-link {


### PR DESCRIPTION
This **pull request** addresses a UI issue where very long headings in the sidebar component overflow their container, breaking the layout.

### Problem
Currently, if a heading label is too long, it extends beyond the sidebar boundaries due to missing style constraints—unlike sidebar links, which are properly contained.

<img width="473" height="109" alt="Screenshot 2025-07-25 at 18-54-57 AdminLTE 4 Sidebar Mini" src="https://github.com/user-attachments/assets/bed8d51a-7868-4fb8-bfba-5ae6c712fa03" />

### Solution
To resolve this, we apply the same `CSS` properties used for link elements, such as text overflow handling, to heading elements. This ensures long headings are truncated or wrapped appropriately, maintaining the sidebar's layout integrity.

<img width="530" height="116" alt="Screenshot 2025-07-25 at 18-50-39 AdminLTE v4 Dashboard" src="https://github.com/user-attachments/assets/f9805590-8590-415e-96d4-6cfb61a096ea" />
