### PR TITLE
Fix menu-open class handling on treeview

### DIFF
--- a/src/ts/treeview.ts
+++ b/src/ts/treeview.ts
@@ -73,10 +73,10 @@ class Treeview {
       })
     }
 
-    this._element.classList.add(CLASS_NAME_MENU_OPEN)
-
     const childElement = this._element?.querySelector(SELECTOR_TREEVIEW_MENU) as HTMLElement | undefined
+
     if (childElement) {
+      this._element.classList.add(CLASS_NAME_MENU_OPEN)
       slideDown(childElement, this._config.animationSpeed)
     }
 
@@ -85,11 +85,10 @@ class Treeview {
 
   close(): void {
     const event = new Event(EVENT_COLLAPSED)
-
-    this._element.classList.remove(CLASS_NAME_MENU_OPEN)
-
     const childElement = this._element?.querySelector(SELECTOR_TREEVIEW_MENU) as HTMLElement | undefined
+
     if (childElement) {
+      this._element.classList.remove(CLASS_NAME_MENU_OPEN)
       slideUp(childElement, this._config.animationSpeed)
     }
 


### PR DESCRIPTION
### Fix: Prevent incorrect `menu-open` behavior on sidebar items without children

Currently, the `menu-open` class is added or removed on all `.nav-item` elements in the sidebar, regardless of whether they contain a submenu. This leads to an unintended UX issue: clicking multiple links with `href="#"` causes multiple items to appear as active/open, even if they don’t have a child menu. This creates the misleading impression that several unrelated items are "open" at once.

For example, in the screenshot below (taken from the **AdminLTE demo**), clicking on items like `Important`, `Warning`, etc., triggers this issue:

<img width="253" height="345" alt="Screenshot 2025-08-01 at 18-35-58 AdminLTE Dashboard v2" src="https://github.com/user-attachments/assets/b19acdfb-7e48-4b0c-90fe-e1a750b02b77" />

### What's changed

This PR updates the behavior to ensure that the `menu-open` class is only toggled on `.nav-item` elements that contain a child `.nav-treeview` menu.