### PR TITLE
Fix floating labels with firefox

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -14,3 +14,4 @@ not Explorer <= 11
 not ie 11
 not android 4.4.3
 not ios_saf < 15.4
+not kaios <= 2.5 # fix floating label issues in Firefox (see https://github.com/postcss/autoprefixer/issues/1533)

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "compile": "npm-run-all css js assets copy-assets docs-compile docs-format flatten-build",
     "production": "npm-run-all clean lint compile bundlewatch",
     "watch": "concurrently \"npm:watch-*\"",
-    "watch-css-main": "nodemon --watch src/scss/ --ext scss --exec \"npm-run-all css-lint css-compile copy-assets\"",
+    "watch-css-main": "nodemon --watch src/scss/ --ext scss --exec \"npm-run-all css-lint css-compile css-prefix copy-assets\"",
     "watch-css-dist": "nodemon --watch dist/css/ --ext css --ignore \"dist/css/*.rtl.*\" --exec \"npm run css-rtl\"",
     "watch-js-main": "nodemon --watch src/ts/ --ext ts --exec \"npm-run-all js-lint js-compile copy-assets\"",
     "watch-assets": "nodemon --watch src/assets/ --exec \"npm run assets\""


### PR DESCRIPTION
### Summary

This PR fixes an issue with **floating labels** in `Firefox` where labels appear in the wrong position due to `:-moz-placeholder` rules being generated in the compiled CSS.

Fix #5901 

### Changes

#### Browserslist update

```diff
+ not kaios <= 2.5 # fix floating label issues in Firefox (see https://github.com/postcss/autoprefixer/issues/1533)
```
- This prevents **Autoprefixer** from generating obsolete `-moz-placeholder` selectors.
- **Bootstrap** applies the same workaround in their own Browserslist config.
- Without this change, `Firefox` treats inputs as if they always contain content, breaking floating labels.

#### Watch task update

```diff
- "watch-css-main": "nodemon --watch src/scss/ --ext scss --exec \"npm-run-all css-lint css-compile copy-assets\"",
+ "watch-css-main": "nodemon --watch src/scss/ --ext scss --exec \"npm-run-all css-lint css-compile css-prefix copy-assets\"",
```
- Adds `css-prefix` command to `watch-css-main` task.
- This ensures `npm run dev` applies the same `PostCSS` prefixing step as `npm run production`.
- Keeps development and production builds consistent, so issues like the Firefox floating label bug can be detected early.

@danny007in @puikinsh please merge as soon as you can, thanks!