### PR TITLE
Fix accessibility validations conflicting with Bootstrap

### DIFF
--- a/src/scss/_accessibility.scss
+++ b/src/scss/_accessibility.scss
@@ -159,12 +159,6 @@
 }
 
 .invalid-feedback {
-  display: block;
-  width: 100%;
-  margin-top: .25rem;
-  font-size: .875em;
-  color: var(--bs-danger);
-
   &[role="alert"] {
     font-weight: 600;
   }

--- a/src/ts/accessibility.ts
+++ b/src/ts/accessibility.ts
@@ -338,10 +338,13 @@ export class AccessibilityManager {
         }
       }
 
-      // Handle invalid states
-      htmlInput.addEventListener('invalid', () => {
-        this.handleFormError(htmlInput)
-      })
+      // Handle invalid state unless the element explicitly opts out via the
+      // 'disable-adminlte-validations' class.
+      if (!htmlInput.classList.contains('disable-adminlte-validations')) {
+        htmlInput.addEventListener('invalid', () => {
+          this.handleFormError(htmlInput)
+        })
+      }
     })
   }
 
@@ -354,7 +357,12 @@ export class AccessibilityManager {
       errorElement.id = errorId
       errorElement.className = 'invalid-feedback'
       errorElement.setAttribute('role', 'alert')
-      input.parentNode?.insertBefore(errorElement, input.nextSibling)
+
+      // Always append the error element as the last child of the parent.
+      // This prevents breaking layouts where inputs use Bootstrap's
+      // `.input-group-text` decorators, ensuring the error stays below
+      // the entire input group.
+      input.parentNode?.append(errorElement)
     }
     
     errorElement.textContent = input.validationMessage


### PR DESCRIPTION
### Accessibility Module Improvements

This PR introduces a set of fixes and improvements to the accessibility utilities to better align with **Bootstrap’s validation system** and prevent layout conflicts.

Fix #5895

#### 1. Refined `.invalid-feedback` styles

```diff
.invalid-feedback {
-  display: block;
-  width: 100%;
-  margin-top: .25rem;
-  font-size: .875em;
-  color: var(--bs-danger);

  &[role="alert"] {
    font-weight: 600;
  }
```

- Removed redundant styles already provided by Bootstrap.
- Prevents conflicts with forms using `.needs-validation`, where `.invalid-feedback` should only appear after `.was-validated` is applied.
- Keeps only the role-specific enhancement (`font-weight: 600` for alerts).

#### 2. Opt-out class for invalid state handling

```diff
-      // Handle invalid states
-      htmlInput.addEventListener('invalid', () => {
-        this.handleFormError(htmlInput)
-      })
+      // Handle invalid state unless the element explicitly opts out via the
+      // 'disable-adminlte-validations' class.
+      if (!htmlInput.classList.contains('disable-adminlte-validations')) {
+        htmlInput.addEventListener('invalid', () => {
+          this.handleFormError(htmlInput)
+        })
+      }
```

- Developers can now add the class `disable-adminlte-validations` to inputs to skip **AdminLTE’s automatic invalid state handling**.
- Provides flexibility for projects that already manage validation feedback differently (for example, when interested only in server-side validations).

#### 3. Correct placement of dynamically inserted error elements

```diff
-      input.parentNode?.insertBefore(errorElement, input.nextSibling)

+      // Always append the error element as the last child of the parent.
+      // This prevents breaking layouts where inputs use Bootstrap's
+      // `.input-group-text` decorators, ensuring the error stays below
+      // the entire input group.
+      input.parentNode?.append(errorElement)
```

- Ensures `.invalid-feedback` messages are always appended at the bottom of the input group or input's parent element.
- Fixes issues where decorators like `.input-group-text` were being pushed out of place.