### PR TITLE
fix(build): sync source banners with package.json version

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "copy-assets": "rimraf src/html/public && shx mkdir -p src/html/public && shx cp -r dist/css dist/js dist/assets src/html/public/",
     "flatten-build": "shx cp -r dist/html/* dist/ && shx rm -rf dist/html && shx rm -rf dist/.astro && shx mkdir -p dist/docs && shx mv dist/docs.html dist/docs/index.html",
     "assets": "node src/config/assets.config.mjs",
+    "version": "node src/config/sync-version.mjs",
     "lint": "npm-run-all --aggregate-output --continue-on-error --parallel js-lint css-lint docs-lint lockfile-lint",
     "clean": "rimraf dist",
     "compile": "npm-run-all css js assets copy-assets docs-compile docs-format flatten-build",

--- a/src/config/sync-version.mjs
+++ b/src/config/sync-version.mjs
@@ -1,0 +1,38 @@
+import { readFileSync, writeFileSync } from 'node:fs'
+import pkg from '../../package.json' with { type: 'json' }
+
+// Keep the hardcoded version in the source banners in sync with package.json.
+// Runs automatically via the "version" npm lifecycle script (see package.json),
+// so `npm version X.Y.Z` stamps the new version before the release is built.
+// The JS dist banner is generated from pkg.version at build time by Rollup,
+// but the SCSS/TS source banners are literals, so they are synced here instead.
+const banners = [
+  'src/scss/adminlte.scss',
+  'src/ts/adminlte.ts'
+]
+
+const versionRegex = /AdminLTE v\d+\.\d+\.\d+(?:-[\w.]+)?/
+
+for (const file of banners) {
+  try {
+    const contents = readFileSync(file, 'utf8')
+
+    if (!versionRegex.test(contents)) {
+      console.warn(`sync-version: no version banner found in ${file}, skipping`)
+      continue
+    }
+
+    const updated = contents.replace(versionRegex, `AdminLTE v${pkg.version}`)
+
+    if (updated === contents) {
+      console.log(`sync-version: ${file} already at v${pkg.version}`)
+      continue
+    }
+
+    writeFileSync(file, updated)
+    console.log(`sync-version: ${file} -> v${pkg.version}`)
+  } catch (error) {
+    console.error(`sync-version: failed to update ${file}`, error)
+    process.exitCode = 1
+  }
+}

--- a/src/scss/adminlte.scss
+++ b/src/scss/adminlte.scss
@@ -1,5 +1,5 @@
 /*!
- *   AdminLTE v4.0.0
+ *   AdminLTE v4.0.2
  *   Author: Colorlib
  *   Website: AdminLTE.io <https://adminlte.io>
  *   License: Open source - MIT <https://opensource.org/licenses/MIT>

--- a/src/ts/adminlte.ts
+++ b/src/ts/adminlte.ts
@@ -8,7 +8,7 @@ import PushMenu from './push-menu.js'
 import { initAccessibility } from './accessibility.js'
 
 /**
- * AdminLTE v4.0.0
+ * AdminLTE v4.0.2
  * Author: Colorlib
  * Website: AdminLTE.io <https://adminlte.io>
  * License: Open source - MIT <https://opensource.org/licenses/MIT>


### PR DESCRIPTION
Fixes #6049

## Problem

The CSS banner is a hardcoded literal at the top of `src/scss/adminlte.scss`, so Sass copies it verbatim into every `dist/css/*.css`. Nothing ever bumps it, so the published CSS reports `AdminLTE v4.0.0` for every release after 4.0.0:

```
dist/css/adminlte.min.css  ->  *   AdminLTE v4.0.0   (stale)
dist/js/adminlte.min.js    ->  * AdminLTE v4.0.2     (correct)
```

The JS banner is correct because `src/config/rollup.config.js` generates it from `pkg.version` at build time. The CSS pipeline (`sass`) has no equivalent step. (`src/ts/adminlte.ts` carries the same stale literal — cosmetic for the bundled JS since terser drops it, but `src/ts/` ships on npm.)

## Fix

Rather than re-bumping a literal by hand each release (which is what got missed), this automates it via npm's `version` lifecycle:

- **New** `src/config/sync-version.mjs` — reads `pkg.version` and stamps it into the SCSS and TS source banners. Lives in `src/config/` alongside the other build configs (npm-ignored, so it doesn't ship).
- **`package.json`** — adds `"version": "node src/config/sync-version.mjs"`, so `npm version X.Y.Z` re-stamps the banners before the release build. This keeps `package.json` as the single source of truth, mirroring how Rollup injects the version for JS.
- Bumps the current literals to `4.0.2`.

## Testing

- `node src/config/sync-version.mjs` updates both source banners; ESLint passes clean.
- A full `npm run css` rebuild now produces `AdminLTE v4.0.2` across all four `dist/css` outputs (LTR/RTL, regular/min) — a clean one-line-per-file change.

`dist/` is intentionally left untouched here; it's regenerated at release time, where the banner now stamps correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)