### PR TITLE
fix(js): drive fullscreen state from fullscreenchange event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Fullscreen state sync:** the fullscreen icons and the `maximized`/`minimized` events are now driven by the native `fullscreenchange` event instead of the request/exit calls. The UI no longer flips when a fullscreen request is denied (permissions policy, missing `allowfullscreen`, lost user gesture), and it now stays in sync when the user exits with `ESC` or `F11`. (builds on @webgo-oss's report in #6055)
+- **Accessibility:** form inputs lacking both an `id` and a `name` now receive a stable, generated error-message id instead of colliding on a shared `-error` id and appending a new orphaned error node on every re-validation. (#6055, reported by @webgo-oss)
+
 ## [4.0.2] - 2026-06-11
 
 ### Fixed

--- a/src/html/components/javascript/fullscreen.mdx
+++ b/src/html/components/javascript/fullscreen.mdx
@@ -40,13 +40,14 @@ fs.outFullscreen()     // exit fullscreen
 | Method | Returns | Description |
 |---|---|---|
 | `toggleFullScreen()` | `void` | Calls `inFullScreen()` if not in fullscreen, otherwise `outFullscreen()`. Checks `document.fullscreenEnabled` first. |
-| `inFullScreen()` | `void` | Calls `document.documentElement.requestFullscreen()`, toggles `.d-none` on the maximize/minimize icons. Fires `maximized.lte.fullscreen`. |
-| `outFullscreen()` | `void` | Calls `document.exitFullscreen()`, toggles `.d-none` on the maximize/minimize icons. Fires `minimized.lte.fullscreen`. |
+| `inFullScreen()` | `void` | Calls `document.documentElement.requestFullscreen()`. The icon `.d-none` toggle and `maximized.lte.fullscreen` event are driven by the resulting `fullscreenchange` event, so a denied request leaves the UI untouched. |
+| `outFullscreen()` | `void` | Calls `document.exitFullscreen()`. The icon `.d-none` toggle and `minimized.lte.fullscreen` event are driven by the resulting `fullscreenchange` event. |
 
 The constructor takes no config — pass only the trigger element.
 
 ##### Notes
 
 - Requires browser support for the [Fullscreen API](https://developer.mozilla.org/docs/Web/API/Fullscreen_API). Check `document.fullscreenEnabled` before invoking.
+- Icon state and events are synced from the native `fullscreenchange` event, so they stay correct when the user exits fullscreen with <kbd>ESC</kbd> or <kbd>F11</kbd>, and a request denied by the browser leaves the icons unchanged.
 - The maximize icon is hidden via the `d-none` Bootstrap utility class (not inline `display`) so it doesn't override the icon library's natural display value — this works correctly with FontAwesome, Lucide, Tabler Icons, etc.
 - Fullscreen on `document.documentElement` (i.e. `<html>`) means the entire page goes fullscreen. To fullscreen just a card, use the [CardWidget `maximize()` method](card-widget.html#programmatic-api) instead.

--- a/src/ts/accessibility.ts
+++ b/src/ts/accessibility.ts
@@ -351,6 +351,14 @@ export class AccessibilityManager {
   }
 
   private handleFormError(input: HTMLInputElement): void {
+    // Inputs lacking both an id and a name would otherwise collide on a
+    // single "-error" id. Assign a stable generated id once and persist it on
+    // the element so repeated `invalid` events reuse the same error node
+    // instead of appending a new orphaned one each time.
+    if (!input.id && !input.name) {
+      input.id = accessibilityUtils.generateId('field')
+    }
+
     const errorId = `${input.id || input.name}-error`
     let errorElement = document.getElementById(errorId)
     

--- a/src/ts/fullscreen.ts
+++ b/src/ts/fullscreen.ts
@@ -24,6 +24,34 @@ const SELECTOR_MAXIMIZE_ICON = '[data-lte-icon="maximize"]'
 const SELECTOR_MINIMIZE_ICON = '[data-lte-icon="minimize"]'
 
 /**
+ * Keep the icons and custom events in sync with the browser's actual
+ * fullscreen state. Driving this from the `fullscreenchange` event (rather
+ * than from the request/exit calls) means the UI stays correct no matter how
+ * the transition happened — including the cases the imperative approach could
+ * never catch: a request that was denied (permissions policy, missing
+ * `allowfullscreen` on an iframe, lost user gesture) and an exit triggered by
+ * the user pressing ESC or F11.
+ */
+function syncFullScreenState(): void {
+  const iconMaximize = document.querySelector<HTMLElement>(SELECTOR_MAXIMIZE_ICON)
+  const iconMinimize = document.querySelector<HTMLElement>(SELECTOR_MINIMIZE_ICON)
+  const isFullScreen = Boolean(document.fullscreenElement)
+
+  // Toggle Bootstrap's .d-none utility instead of hardcoding inline
+  // display:block. The previous approach overrode the icon library's
+  // natural display value (eg. some icon fonts use inline-block) and
+  // caused the icon to shift its position. Fixes #6021.
+  iconMaximize?.classList.toggle('d-none', isFullScreen)
+  iconMinimize?.classList.toggle('d-none', !isFullScreen)
+
+  const eventName = isFullScreen ? EVENT_MAXIMIZED : EVENT_MINIMIZED
+
+  document.querySelectorAll(SELECTOR_FULLSCREEN_TOGGLE).forEach(button => {
+    button.dispatchEvent(new Event(eventName))
+  })
+}
+
+/**
  * Class Definition.
  * ============================================================================
  */
@@ -37,54 +65,29 @@ class FullScreen {
   }
 
   inFullScreen(): void {
-    const event = new Event(EVENT_MAXIMIZED)
-
-    const iconMaximize = document.querySelector<HTMLElement>(SELECTOR_MAXIMIZE_ICON)
-    const iconMinimize = document.querySelector<HTMLElement>(SELECTOR_MINIMIZE_ICON)
-
-    void document.documentElement.requestFullscreen()
-
-    // Toggle Bootstrap's .d-none utility instead of hardcoding inline
-    // display:block. The previous approach overrode the icon library's
-    // natural display value (eg. some icon fonts use inline-block) and
-    // caused the icon to shift its position. Fixes #6021.
-    if (iconMaximize) {
-      iconMaximize.classList.add('d-none')
-    }
-
-    if (iconMinimize) {
-      iconMinimize.classList.remove('d-none')
-    }
-
-    this._element.dispatchEvent(event)
+    // Fire-and-forget: the resulting `fullscreenchange` event updates the
+    // icons and dispatches `maximized.lte.fullscreen`. If the request is
+    // denied the event never fires, so the UI correctly stays untouched.
+    void document.documentElement.requestFullscreen().catch(() => {
+      // Request denied — nothing to undo.
+    })
   }
 
   outFullscreen(): void {
-    const event = new Event(EVENT_MINIMIZED)
-
-    const iconMaximize = document.querySelector<HTMLElement>(SELECTOR_MAXIMIZE_ICON)
-    const iconMinimize = document.querySelector<HTMLElement>(SELECTOR_MINIMIZE_ICON)
-
-    void document.exitFullscreen()
-
-    if (iconMaximize) {
-      iconMaximize.classList.remove('d-none')
-    }
-
-    if (iconMinimize) {
-      iconMinimize.classList.add('d-none')
-    }
-
-    this._element.dispatchEvent(event)
+    void document.exitFullscreen().catch(() => {
+      // Exit failed — nothing to undo.
+    })
   }
 
   toggleFullScreen(): void {
-    if (document.fullscreenEnabled) {
-      if (document.fullscreenElement) {
-        this.outFullscreen()
-      } else {
-        this.inFullScreen()
-      }
+    if (!document.fullscreenEnabled) {
+      return
+    }
+
+    if (document.fullscreenElement) {
+      this.outFullscreen()
+    } else {
+      this.inFullScreen()
     }
   }
 }
@@ -94,6 +97,8 @@ class FullScreen {
  * ============================================================================
  */
 onDOMContentLoaded(() => {
+  document.addEventListener('fullscreenchange', syncFullScreenState)
+
   const buttons = document.querySelectorAll(SELECTOR_FULLSCREEN_TOGGLE)
 
   buttons.forEach(btn => {


### PR DESCRIPTION
## Summary

A cleaner take on the edge cases raised in #6055 (thanks @webgo-oss). Instead of toggling icons/events imperatively after `requestFullscreen()`/`exitFullscreen()`, a single **`fullscreenchange`** listener is now the source of truth for the fullscreen UI state.

## Why

The old approach mutated the UI right after firing the request, which desynced it in two ways:

1. **Denied request** — a request rejected by the browser (permissions policy, missing `allowfullscreen` on an iframe, lost user gesture) still flipped the icons and fired `maximized.lte.fullscreen` even though we never entered fullscreen. *(This is the case #6055 targeted.)*
2. **ESC / F11 exit** — exiting fullscreen with the keyboard never runs `outFullscreen()`, so the icons stayed stuck in the "in fullscreen" state. *(Not covered by #6055.)*

Driving icon `.d-none` toggling and event dispatch from `fullscreenchange` fixes both, because the browser only emits that event when the state actually changes.

## Notes vs. #6055

- The public methods keep their documented `void` signatures — #6055 made them `async`/`Promise<void>`, which diverges from `fullscreen.mdx` (docs updated here to match the event-driven behavior).
- Error-ID fix: inputs lacking **both** `id` and `name` collided on a shared `-error` id. #6055's fallback regenerated a random id on every `invalid` event, so each re-validation appended a new orphaned error node. Here the generated id is assigned to the element once, so the same error node is reused.
- Dropped the `firstElement?.focus()` change — that branch only runs when `document.activeElement === lastElement`, which guarantees the focusable list is non-empty and `firstElement` is defined.

## Testing

- `npm run js-lint` — clean
- `tsc --noEmit` — clean
- `npm run js-compile` — builds
- Manually: enter via button, exit via ESC/F11, and a denied request in a sandboxed iframe — icons stay correct in all three.

## Type of Change

- Bug Fix
- Accessibility Improvement

Closes #6055