### PR TITLE
Resolved issue using hotwired/turbo links which broke PushMenu and TreeView

### DIFF
--- a/.bundlewatch.config.json
+++ b/.bundlewatch.config.json
@@ -22,7 +22,7 @@
     },
     {
       "path": "./dist/js/adminlte.min.js",
-      "maxSize": "5.5 kB"
+      "maxSize": "5.56 kB"
     }
   ]
 }

--- a/src/ts/util/index.ts
+++ b/src/ts/util/index.ts
@@ -1,21 +1,29 @@
-const domContentLoadedCallbacks: Array<() => void> = []
+type DOMContentLoadedCallback = () => void;
 
-const onDOMContentLoaded = (callback: () => void): void => {
-  if (document.readyState === 'loading') {
-    // add listener on the first call when the document is in loading state
-    if (!domContentLoadedCallbacks.length) {
-      document.addEventListener('DOMContentLoaded', () => {
-        for (const callback of domContentLoadedCallbacks) {
-          callback()
-        }
-      })
+const adminLTEState = (() => {
+  const callbacks: DOMContentLoadedCallback[] = [];
+  let isInitialized = false;
+  return {
+    registerCallback(callback: DOMContentLoadedCallback): void {
+      callbacks.push(callback);
+    },
+    initialize(): void {
+      if (isInitialized) return;
+      isInitialized = true;
+      for (const callback of callbacks) {
+        callback();
+      }
+    },
+    reset(): void {
+      isInitialized = false;
     }
+  };
+})();
+const onDOMContentLoaded = adminLTEState.registerCallback;
 
-    domContentLoadedCallbacks.push(callback)
-  } else {
-    callback()
-  }
-}
+document.addEventListener('DOMContentLoaded', adminLTEState.initialize);
+document.addEventListener('turbo:load', adminLTEState.initialize);
+document.addEventListener('turbo:before-render', adminLTEState.reset);
 
 /* ES2022 UTILITY FUNCTIONS */
 


### PR DESCRIPTION
Hello,

I was having the same problem as issue #5890 and #563  and since the newer Symfony 8 ships with hotwired/turbo I figured I wanted to solve this problem. Using the TreeView or PushMenu for the first time worked fine, but after clicking a link, it wouldn't work anymore. That's because hotwired/turbo replaces the <body> instead of navigating to a new page.

What I've done is creating a new state manager, which fires on the first load, as we're used to. However, it also hooks into turbo's specific lifecycle events (turbo:before-render and turbo:load). By resetting an internal initialization flag right before turbo renders the new content, the manager is able to re-trigger the initialization scripts needed for the TreeView and PushMenu to work.