### PR TITLE
feat(js): support Hotwired Turbo by re-initialising plugins on turbo:load

### DIFF
--- a/.bundlewatch.config.json
+++ b/.bundlewatch.config.json
@@ -22,7 +22,7 @@
     },
     {
       "path": "./dist/js/adminlte.min.js",
-      "maxSize": "5.5 kB"
+      "maxSize": "5.8 kB"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Hotwired Turbo / Turbo Drive support:** plugins now re-initialise on `turbo:load`, so PushMenu, TreeView and the other JS components keep working after Turbo swaps the `<body>` on in-app navigation (previously they went dead after the first link click). Each init cycle uses an `AbortController` whose signal is aborted on `turbo:before-render`, so the `window`/`document`-level listeners are torn down before re-init instead of stacking up on every navigation. (#563, #5890 — diagnosed and prototyped by @MarkDaleman in #6058)
+
 ### Fixed
 
 - **Fullscreen state sync:** the fullscreen icons and the `maximized`/`minimized` events are now driven by the native `fullscreenchange` event instead of the request/exit calls. The UI no longer flips when a fullscreen request is denied (permissions policy, missing `allowfullscreen`, lost user gesture), and it now stays in sync when the user exits with `ESC` or `F11`. (builds on @webgo-oss's report in #6055)

--- a/src/html/components/docs/faq.mdx
+++ b/src/html/components/docs/faq.mdx
@@ -146,6 +146,13 @@ Check that the PushMenu plugin is loaded. It's bundled into `adminlte.js` — ma
 </details>
 
 <details class="faq-item">
+<summary>PushMenu / TreeView stop working after navigating with Hotwired Turbo (or Turbolinks).</summary>
+
+This is handled automatically. Turbo Drive swaps the `<body>` instead of doing a full page load, so AdminLTE re-initialises its plugins on the `turbo:load` event (and tears down its `window`/`document` listeners on `turbo:before-render` so they don't accumulate). As long as `adminlte.js` is loaded once in the `<head>` or as a persistent (`data-turbo-track="reload"`) script, the menus keep working across in-app navigations.
+
+</details>
+
+<details class="faq-item">
 <summary>Dark mode doesn't persist after refresh.</summary>
 
 The included [Color Mode](color-mode.html) toggle writes to `localStorage` under the key `lte-theme`. If you're using a different toggle implementation, make sure it both sets `document.documentElement.setAttribute('data-bs-theme', ...)` and writes to localStorage on change.

--- a/src/ts/accessibility.ts
+++ b/src/ts/accessibility.ts
@@ -3,6 +3,8 @@
  * WCAG 2.1 AA Compliance Features
  */
 
+import { getLifecycleSignal } from './util/index'
+
 export interface AccessibilityConfig {
   announcements: boolean
   skipLinks: boolean
@@ -15,6 +17,9 @@ export class AccessibilityManager {
   private config: AccessibilityConfig
   private liveRegion: HTMLElement | null = null
   private focusHistory: HTMLElement[] = []
+  // Listeners bound to `document` survive Turbo's <body> swap, so they are
+  // registered with this signal and torn down before the next re-init.
+  private readonly signal: AbortSignal = getLifecycleSignal()
 
   constructor(config: Partial<AccessibilityConfig> = {}) {
     this.config = {
@@ -120,7 +125,7 @@ export class AccessibilityManager {
       if (event.key === 'Escape') {
         this.handleEscapeKey(event)
       }
-    })
+    }, { signal: this.signal })
 
     // Focus management for modals and dropdowns
     this.initModalFocusManagement()
@@ -192,7 +197,7 @@ export class AccessibilityManager {
         event.preventDefault()
         target.click()
       }
-    })
+    }, { signal: this.signal })
   }
 
   private handleMenuNavigation(event: KeyboardEvent): void {
@@ -244,16 +249,20 @@ export class AccessibilityManager {
       // Disable smooth scrolling
       document.documentElement.style.scrollBehavior = 'auto'
       
-      // Reduce animation duration
-      const style = document.createElement('style')
-      style.textContent = `
-        *, *::before, *::after {
-          animation-duration: 0.01ms !important;
-          animation-iteration-count: 1 !important;
-          transition-duration: 0.01ms !important;
-        }
-      `
-      document.head.append(style)
+      // Reduce animation duration. The <head> survives Turbo navigations, so
+      // only inject the override stylesheet once to avoid stacking duplicates.
+      if (!document.getElementById('adminlte-reduce-motion')) {
+        const style = document.createElement('style')
+        style.id = 'adminlte-reduce-motion'
+        style.textContent = `
+          *, *::before, *::after {
+            animation-duration: 0.01ms !important;
+            animation-iteration-count: 1 !important;
+            transition-duration: 0.01ms !important;
+          }
+        `
+        document.head.append(style)
+      }
     }
   }
 
@@ -283,6 +292,11 @@ export class AccessibilityManager {
       childList: true,
       subtree: true
     })
+
+    // Stop observing the old <body> before Turbo swaps in a new one.
+    this.signal.addEventListener('abort', () => {
+      observer.disconnect()
+    }, { once: true })
   }
 
   // WCAG 1.3.1: Info and Relationships
@@ -394,7 +408,7 @@ export class AccessibilityManager {
       
       // Store previous focus
       this.focusHistory.push(document.activeElement as HTMLElement)
-    })
+    }, { signal: this.signal })
 
     document.addEventListener('hidden.bs.modal', () => {
       // Restore previous focus
@@ -402,7 +416,7 @@ export class AccessibilityManager {
       if (previousElement) {
         previousElement.focus()
       }
-    })
+    }, { signal: this.signal })
   }
 
   // Dropdown focus management
@@ -415,7 +429,7 @@ export class AccessibilityManager {
       if (firstItem) {
         firstItem.focus()
       }
-    })
+    }, { signal: this.signal })
   }
 
   // Public API methods

--- a/src/ts/fullscreen.ts
+++ b/src/ts/fullscreen.ts
@@ -7,6 +7,7 @@
  */
 
 import {
+  getLifecycleSignal,
   onDOMContentLoaded
 } from './util/index'
 
@@ -97,7 +98,7 @@ class FullScreen {
  * ============================================================================
  */
 onDOMContentLoaded(() => {
-  document.addEventListener('fullscreenchange', syncFullScreenState)
+  document.addEventListener('fullscreenchange', syncFullScreenState, { signal: getLifecycleSignal() })
 
   const buttons = document.querySelectorAll(SELECTOR_FULLSCREEN_TOGGLE)
 

--- a/src/ts/layout.ts
+++ b/src/ts/layout.ts
@@ -7,6 +7,7 @@
  */
 
 import {
+  getLifecycleSignal,
   onDOMContentLoaded
 } from './util/index'
 
@@ -62,7 +63,7 @@ class Layout {
 
 onDOMContentLoaded(() => {
   const layout = new Layout(document.body)
-  window.addEventListener('resize', () => layout.holdTransition(200))
+  window.addEventListener('resize', () => layout.holdTransition(200), { signal: getLifecycleSignal() })
 
   setTimeout(() => {
     document.body.classList.add(CLASS_NAME_APP_LOADED)

--- a/src/ts/push-menu.ts
+++ b/src/ts/push-menu.ts
@@ -7,6 +7,7 @@
  */
 
 import {
+  getLifecycleSignal,
   onDOMContentLoaded
 } from './util/index'
 
@@ -365,7 +366,7 @@ onDOMContentLoaded(() => {
   window.addEventListener('resize', () => {
     pushMenu.setupSidebarBreakPoint()
     pushMenu.updateStateByResponsiveLogic()
-  })
+  }, { signal: getLifecycleSignal() })
 
   // Create the sidebar overlay element and append it to the app wrapper.
 

--- a/src/ts/util/index.ts
+++ b/src/ts/util/index.ts
@@ -1,21 +1,79 @@
-const domContentLoadedCallbacks: Array<() => void> = []
+/**
+ * Lifecycle management
+ * ============================================================================
+ *
+ * Plugins register their initialisation through `onDOMContentLoaded`. Besides
+ * the initial page load, every registered callback is re-run on Hotwired Turbo
+ * navigations (`turbo:load`): Turbo Drive swaps the <body> without a full page
+ * reload, so without re-initialisation plugins such as PushMenu and TreeView
+ * stop working after the first in-app link click (#563, #5890).
+ *
+ * Re-running init would normally leak listeners, because callbacks also bind to
+ * `window`/`document`, which survive Turbo's <body> swap. To prevent that, each
+ * cycle has its own `AbortController`: callbacks should attach their
+ * window/document-level listeners with the signal from `getLifecycleSignal()`.
+ * The signal is aborted on `turbo:before-render`, tearing down the previous
+ * cycle's listeners before the callbacks run again. Listeners bound to elements
+ * inside <body> don't need the signal — Turbo discards the old <body>, so they
+ * are cleaned up automatically.
+ */
 
-const onDOMContentLoaded = (callback: () => void): void => {
-  if (document.readyState === 'loading') {
-    // add listener on the first call when the document is in loading state
-    if (!domContentLoadedCallbacks.length) {
-      document.addEventListener('DOMContentLoaded', () => {
-        for (const callback of domContentLoadedCallbacks) {
-          callback()
-        }
-      })
-    }
+const lifecycleCallbacks: Array<() => void> = []
 
-    domContentLoadedCallbacks.push(callback)
-  } else {
+// Mutable state is held on an object so the lifecycle hooks below can update it
+// without reassigning top-level bindings.
+const lifecycleState = {
+  controller: new AbortController(),
+  hasInitialized: false
+}
+
+/**
+ * The AbortSignal for the current lifecycle. Pass it as the
+ * `{ signal }` option to window/document `addEventListener` calls made during
+ * initialisation so they are removed automatically on the next Turbo render.
+ */
+const getLifecycleSignal = (): AbortSignal => lifecycleState.controller.signal
+
+const runLifecycleCallbacks = (): void => {
+  if (lifecycleState.hasInitialized) {
+    return
+  }
+
+  lifecycleState.hasInitialized = true
+
+  for (const callback of lifecycleCallbacks) {
     callback()
   }
 }
+
+const onDOMContentLoaded = (callback: () => void): void => {
+  lifecycleCallbacks.push(callback)
+
+  // Late registration: the batch for the current cycle has already run (the
+  // script loaded after DOMContentLoaded, or a callback was registered after a
+  // Turbo visit), so run the newcomer immediately rather than stranding it
+  // until the next navigation. Preserves the original non-loading behaviour.
+  if (lifecycleState.hasInitialized) {
+    callback()
+  }
+}
+
+// Initial page load.
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', runLifecycleCallbacks, { once: true })
+} else {
+  runLifecycleCallbacks()
+}
+
+// Hotwired Turbo: drop the previous cycle's window/document listeners, then
+// re-run initialisation against the freshly rendered <body>.
+document.addEventListener('turbo:before-render', () => {
+  lifecycleState.controller.abort()
+  lifecycleState.controller = new AbortController()
+  lifecycleState.hasInitialized = false
+})
+
+document.addEventListener('turbo:load', runLifecycleCallbacks)
 
 /* ES2022 UTILITY FUNCTIONS */
 
@@ -134,6 +192,7 @@ const slideToggle = (target: HTMLElement, duration = 500) => {
 
 export {
   onDOMContentLoaded,
+  getLifecycleSignal,
   slideUp,
   slideDown,
   slideToggle,


### PR DESCRIPTION
## Summary

Makes AdminLTE's JS plugins survive [Hotwired Turbo](https://turbo.hotwired.dev/) / Turbo Drive navigation. Builds on the problem **diagnosed and prototyped by @MarkDaleman in #6058** — thank you! 🙏

Turbo Drive swaps the `<body>` instead of doing a full page load, so `DOMContentLoaded` fires only once. AdminLTE initialised every plugin from that single event, so after the first Turbo visit the new `<body>` had no listeners and **PushMenu / TreeView went dead** (#563, #5890).

## Approach

Re-run all init callbacks on `turbo:load`. The subtle part — and why #6058 needed rework — is that several callbacks bind to **`window` / `document`** (resize handlers in Layout & PushMenu, the accessibility keyboard/modal/dropdown listeners, the fullscreen `fullscreenchange` listener). Those targets **survive** Turbo's `<body>` swap, so naively re-running init stacks a fresh copy of each listener on *every* navigation — an unbounded leak plus multiplied handler execution (e.g. duplicate screen-reader announcements).

So each init cycle now owns an `AbortController`:

- window/document listeners are registered with its signal via the new `getLifecycleSignal()` helper;
- the signal is **aborted on `turbo:before-render`**, tearing those listeners down before the callbacks run again;
- listeners bound to elements **inside `<body>`** (TreeView/PushMenu buttons, the sidebar overlay) need no signal — Turbo discards the old `<body>`, so they're collected automatically.

Plus a few correctness fixes surfaced along the way:

- restored the original **immediate-call** behaviour for callbacks registered after the document already loaded (async / late init) — #6058 dropped this;
- the reduced-motion `<style>` is injected **once** (the `<head>` persists across Turbo renders);
- the error-announcement `MutationObserver` is disconnected on abort.

**Non-Turbo pages are unaffected:** `turbo:*` events never fire, so init happens exactly as before and the signals never abort.

## Testing

- `npm run js-lint` — clean
- `tsc --noEmit` — clean
- `npm run js` (compile + minify) — builds; bumped the `adminlte.min.js` bundlewatch limit 5.5 → 5.8 kB (gzip is now 5.71 kB)
- Added a Turbo FAQ entry and a CHANGELOG note.

> Note: the Turbo navigation path can't be exercised by the static demo, so it's verified by build + code review rather than an automated browser test. Manual check in a Turbo app recommended before release.

## Type of Change

- New Feature (Turbo/Hotwire compatibility)
- Bug Fix (#563, #5890)

Closes #6058