### PR TITLE
Fix push menu plugin to allow collapsed sidebar at initialization

### DIFF
--- a/src/ts/push-menu.ts
+++ b/src/ts/push-menu.ts
@@ -341,12 +341,12 @@ class PushMenu extends BaseComponent {
 
     // When persistence is enabled and screen size is above the breakpoint, load
     // the saved sidebar state from local storage. Otherwise, use responsive
-    // logic to set the initial state. On low screen sizes, the sidebar should
-    // always be collapsed by default unless explicitly opened.
+    // logic to set the initial state (unless explicitly set as collapsed at
+    // initialization).
 
     if (this._config.enablePersistence && !this.isMobileSize()) {
       this.loadSidebarState()
-    } else {
+    } else if (!this.isCollapsed()) {
       this.updateStateByResponsiveLogic()
     }
   }


### PR DESCRIPTION
This pull request updates the sidebar initialization logic in `push-menu.ts` to better handle cases where the sidebar is explicitly set as collapsed. Now, the responsive logic for setting the sidebar state only runs if the sidebar is not already collapsed, preventing unwanted overrides. This way, a user can use the `sidebar-collapse` class on the body tag to get a collapsed sidebar on page initialization.

Sidebar state initialization improvements:

* Updated the sidebar initialization in the `PushMenu` class so that responsive logic is only applied if the sidebar is not already collapsed, ensuring explicit collapsed states are respected.