### PR TITLE
Add correct docstrings to base and push menu components.

### DIFF
--- a/src/ts/base-component.ts
+++ b/src/ts/base-component.ts
@@ -1,34 +1,61 @@
 /**
- * --------------------------------------------
+ * ----------------------------------------------------------------------------
  * @file AdminLTE base-component.ts
  * @description Shared component lifecycle for AdminLTE plugins: a per-element
  * instance registry (getInstance / getOrCreateInstance / dispose) and a
  * consistent custom-event contract, mirroring Bootstrap's component API.
  * @license MIT
- * --------------------------------------------
+ * ----------------------------------------------------------------------------
  */
 
 /**
- * element -> (data key -> component instance). WeakMap keys don't prevent
- * garbage collection, so instances die with their elements — important under
- * Hotwired Turbo, which swaps the whole <body> on navigation.
+ * Component registry:
+ * A WeakMap of elements to store component instances. Each element can have
+ * multiple component instances associated with it, keyed by the component's
+ * DATA_KEY: element -> (data key -> component instance).
+ * The WeakMap keys don't prevent garbage collection, so instances die with
+ * their elements, this is important under Hotwired Turbo, which swaps the
+ * whole <body> on navigation.
  */
 const componentRegistry = new WeakMap<Element, Map<string, BaseComponent>>()
 
+/**
+ * ----------------------------------------------------------------------------
+ * Class Definition
+ * ----------------------------------------------------------------------------
+ */
+
 class BaseComponent {
+  /**
+   * Get the component name. Subclasses must override this getter to provide
+   * their own name.
+   *
+   * @returns The component name.
+   */
   static get NAME(): string {
-    throw new Error('Component subclasses must override the static NAME getter.')
+    throw new Error('Component subclasses must override the NAME getter.')
   }
 
+  /**
+   * Get the component's data key.
+   *
+   * @returns The component's data key.
+   */
   static get DATA_KEY(): string {
     return `lte.${this.NAME}`
   }
 
   /**
+   * Get the component instance associated with the given element, if any.
    * Untyped registry lookup. Every component exposes a typed wrapper
    * (e.g. CardWidget.getInstance()) built on top of this.
+   *
+   * @param element The element to look up.
+   * @returns The component instance, or null if none.
    */
-  protected static _getInstance(element: Element | null | undefined): BaseComponent | null {
+  protected static _getInstance(
+    element: Element | null | undefined
+  ): BaseComponent | null {
     if (!element) {
       return null
     }
@@ -36,24 +63,43 @@ class BaseComponent {
     return componentRegistry.get(element)?.get(this.DATA_KEY) ?? null
   }
 
+  /**
+   * The element this component instance is associated with.
+   */
   _element: HTMLElement
 
+  /**
+   * Create a new component instance associated with the given element.
+   *
+   * @param element The element to associate with this instance.
+   */
   constructor(element: HTMLElement) {
     this._element = element
 
+    // Get or create the map of component instances for this element.
+
     const instances = componentRegistry.get(element) ?? new Map<string, BaseComponent>()
+
+    // Store this instance in the map, keyed by the component's data key.
+
     componentRegistry.set(element, instances)
     instances.set((this.constructor as typeof BaseComponent).DATA_KEY, this)
   }
 
   /**
    * Remove this instance from the registry so getInstance() no longer
-   * returns it. Subclasses release their own resources, then call
+   * returns it. Subclasses release their own resources, then should call
    * super.dispose().
    */
   dispose(): void {
+    // Remove this instance from the registry so getInstance() no longer
+    // returns it.
+
     const instances = componentRegistry.get(this._element)
     instances?.delete((this.constructor as typeof BaseComponent).DATA_KEY)
+
+    // If this was the last instance for this element, remove the element from
+    // the registry entirely.
 
     if (instances?.size === 0) {
       componentRegistry.delete(this._element)
@@ -65,20 +111,36 @@ class BaseComponent {
  * Dispatch a namespaced custom event that bubbles — so applications can
  * listen once on `document` — and can optionally carry a payload or be
  * canceled. Returns the event so callers can check `defaultPrevented`.
+ *
+ * @param element The element to dispatch the event on.
+ * @param name The event name.
+ * @param options Optional event options: `cancelable` and `detail`.
+ * @returns The dispatched CustomEvent.
  */
 const dispatchCustomEvent = <T = undefined>(
   element: Element,
   name: string,
   options: { cancelable?: boolean; detail?: T } = {}
 ): CustomEvent<T | undefined> => {
+  // Create a custom event with the given name and options. The event bubbles
+  // and can be canceled.
+
   const event = new CustomEvent<T | undefined>(name, {
     bubbles: true,
     cancelable: options.cancelable ?? false,
     detail: options.detail
   })
 
+  // Dispatch the event on the given element.
+
   element.dispatchEvent(event)
   return event
 }
+
+/**
+ * ----------------------------------------------------------------------------
+ * Exports
+ * ----------------------------------------------------------------------------
+ */
 
 export { BaseComponent, dispatchCustomEvent }

--- a/src/ts/base-component.ts
+++ b/src/ts/base-component.ts
@@ -1,61 +1,45 @@
 /**
- * ----------------------------------------------------------------------------
+ * --------------------------------------------
  * @file AdminLTE base-component.ts
  * @description Shared component lifecycle for AdminLTE plugins: a per-element
  * instance registry (getInstance / getOrCreateInstance / dispose) and a
  * consistent custom-event contract, mirroring Bootstrap's component API.
  * @license MIT
- * ----------------------------------------------------------------------------
+ * --------------------------------------------
  */
 
 /**
- * Component registry:
- * A WeakMap of elements to store component instances. Each element can have
- * multiple component instances associated with it, keyed by the component's
- * DATA_KEY: element -> (data key -> component instance).
- * The WeakMap keys don't prevent garbage collection, so instances die with
- * their elements, this is important under Hotwired Turbo, which swaps the
- * whole <body> on navigation.
+ * Component registry: element -> (data key -> component instance). A single
+ * element can host several components at once, each stored under its own
+ * DATA_KEY. WeakMap keys don't prevent garbage collection, so instances die
+ * with their elements — important under Hotwired Turbo, which swaps the whole
+ * <body> on navigation.
  */
 const componentRegistry = new WeakMap<Element, Map<string, BaseComponent>>()
 
-/**
- * ----------------------------------------------------------------------------
- * Class Definition
- * ----------------------------------------------------------------------------
- */
-
 class BaseComponent {
   /**
-   * Get the component name. Subclasses must override this getter to provide
-   * their own name.
-   *
-   * @returns The component name.
+   * Subclasses must override this getter to declare their own name.
    */
   static get NAME(): string {
-    throw new Error('Component subclasses must override the NAME getter.')
+    throw new Error('Component subclasses must override the static NAME getter.')
   }
 
   /**
-   * Get the component's data key.
-   *
-   * @returns The component's data key.
+   * Key this component is registered under: `lte.<name>`.
    */
   static get DATA_KEY(): string {
     return `lte.${this.NAME}`
   }
 
   /**
-   * Get the component instance associated with the given element, if any.
    * Untyped registry lookup. Every component exposes a typed wrapper
    * (e.g. CardWidget.getInstance()) built on top of this.
    *
    * @param element The element to look up.
-   * @returns The component instance, or null if none.
+   * @returns The instance for this component, or null if there is none.
    */
-  protected static _getInstance(
-    element: Element | null | undefined
-  ): BaseComponent | null {
+  protected static _getInstance(element: Element | null | undefined): BaseComponent | null {
     if (!element) {
       return null
     }
@@ -64,43 +48,34 @@ class BaseComponent {
   }
 
   /**
-   * The element this component instance is associated with.
+   * The element this instance is attached to.
    */
   _element: HTMLElement
 
   /**
-   * Create a new component instance associated with the given element.
+   * Attach a new instance to the given element and register it under the
+   * subclass's DATA_KEY.
    *
-   * @param element The element to associate with this instance.
+   * @param element The element to attach this instance to.
    */
   constructor(element: HTMLElement) {
     this._element = element
 
-    // Get or create the map of component instances for this element.
-
     const instances = componentRegistry.get(element) ?? new Map<string, BaseComponent>()
-
-    // Store this instance in the map, keyed by the component's data key.
-
     componentRegistry.set(element, instances)
     instances.set((this.constructor as typeof BaseComponent).DATA_KEY, this)
   }
 
   /**
    * Remove this instance from the registry so getInstance() no longer
-   * returns it. Subclasses release their own resources, then should call
+   * returns it. Subclasses release their own resources, then call
    * super.dispose().
    */
   dispose(): void {
-    // Remove this instance from the registry so getInstance() no longer
-    // returns it.
-
     const instances = componentRegistry.get(this._element)
     instances?.delete((this.constructor as typeof BaseComponent).DATA_KEY)
 
-    // If this was the last instance for this element, remove the element from
-    // the registry entirely.
-
+    // Drop the element's entry once it holds no components at all.
     if (instances?.size === 0) {
       componentRegistry.delete(this._element)
     }
@@ -113,34 +88,24 @@ class BaseComponent {
  * canceled. Returns the event so callers can check `defaultPrevented`.
  *
  * @param element The element to dispatch the event on.
- * @param name The event name.
- * @param options Optional event options: `cancelable` and `detail`.
- * @returns The dispatched CustomEvent.
+ * @param name The namespaced event name, e.g. `collapse.lte.push-menu`.
+ * @param options `cancelable` opts the event into preventDefault(); `detail`
+ *   is the payload handed to listeners.
+ * @returns The dispatched event, after listeners have run.
  */
 const dispatchCustomEvent = <T = undefined>(
   element: Element,
   name: string,
   options: { cancelable?: boolean; detail?: T } = {}
 ): CustomEvent<T | undefined> => {
-  // Create a custom event with the given name and options. The event bubbles
-  // and can be canceled.
-
   const event = new CustomEvent<T | undefined>(name, {
     bubbles: true,
     cancelable: options.cancelable ?? false,
     detail: options.detail
   })
 
-  // Dispatch the event on the given element.
-
   element.dispatchEvent(event)
   return event
 }
-
-/**
- * ----------------------------------------------------------------------------
- * Exports
- * ----------------------------------------------------------------------------
- */
 
 export { BaseComponent, dispatchCustomEvent }

--- a/src/ts/push-menu.ts
+++ b/src/ts/push-menu.ts
@@ -76,50 +76,40 @@ const Defaults: Config = {
  */
 
 class PushMenu extends BaseComponent {
-  /**
-   * Get the component name.
-   *
-   * @returns The component name.
-   */
   static get NAME(): string {
     return NAME
   }
 
   /**
-   * Get the component instance associated with the given element, if any.
+   * Look up the PushMenu already attached to the given element.
    *
-   * @param element The element to look up.
-   * @returns The component instance, or null if none.
+   * @param element The sidebar element to look up.
+   * @returns The existing instance, or null if the sidebar has none yet.
    */
   static getInstance(element: Element | null | undefined): PushMenu | null {
     return this._getInstance(element) as PushMenu | null
   }
 
   /**
-   * Get the component instance associated with the given element, or create a
-   * new one if none exists.
+   * Look up the PushMenu attached to the given element, creating one when the
+   * element has none. `config` is ignored if an instance already exists.
    *
-   * @param element The element to look up or associate with a new instance.
-   * @param config Optional configuration for a new instance.
-   * @returns The component instance.
+   * @param element The sidebar element.
+   * @param config Overrides merged over the defaults for a new instance.
+   * @returns The existing or newly created instance.
    */
-  static getOrCreateInstance(
-    element: HTMLElement,
-    config: Partial<Config> = {}
-  ): PushMenu {
+  static getOrCreateInstance(element: HTMLElement, config: Partial<Config> = {}): PushMenu {
     return this.getInstance(element) ?? new this(element, config)
   }
 
   /**
-   * The configuration for this instance.
+   * The defaults merged with the overrides this instance was created with.
    */
   _config: Config
 
   /**
-   * Create a new PushMenu instance associated with the given element.
-   *
-   * @param element The element to associate with this instance.
-   * @param config Optional configuration for this instance.
+   * @param element The sidebar element to attach to.
+   * @param config Overrides merged over the defaults.
    */
   constructor(element: HTMLElement, config: Partial<Config> = {}) {
     super(element)
@@ -167,16 +157,9 @@ class PushMenu extends BaseComponent {
    * Expand the sidebar menu.
    */
   expand(): void {
-    // Dispatch the "open" event, which is cancelable: preventDefault() should
-    // keep the sidebar in its current state.
-
-    const evt = dispatchCustomEvent(
-      this._element,
-      EVENT_OPEN,
-      { cancelable: true }
-    )
-
-    if (evt.defaultPrevented) {
+    // The "open" event is cancelable: preventDefault() keeps the sidebar
+    // in its current state.
+    if (dispatchCustomEvent(this._element, EVENT_OPEN, { cancelable: true }).defaultPrevented) {
       return
     }
 
@@ -189,8 +172,6 @@ class PushMenu extends BaseComponent {
       document.body.classList.add(CLASS_NAME_SIDEBAR_OPEN)
     }
 
-    // Dispatch the "opened" event to indicate the sidebar is now open.
-
     dispatchCustomEvent(this._element, EVENT_OPENED)
   }
 
@@ -198,16 +179,9 @@ class PushMenu extends BaseComponent {
    * Collapse the sidebar menu.
    */
   collapse(): void {
-    // Dispatch the "collapse" event, which is cancelable: preventDefault()
-    // should keep the sidebar in its current state.
-
-    const evt = dispatchCustomEvent(
-      this._element,
-      EVENT_COLLAPSE,
-      { cancelable: true }
-    )
-
-    if (evt.defaultPrevented) {
+    // The "collapse" event is cancelable: preventDefault() keeps the sidebar
+    // in its current state.
+    if (dispatchCustomEvent(this._element, EVENT_COLLAPSE, { cancelable: true }).defaultPrevented) {
       return
     }
 
@@ -216,8 +190,6 @@ class PushMenu extends BaseComponent {
 
     document.body.classList.remove(CLASS_NAME_SIDEBAR_OPEN)
     document.body.classList.add(CLASS_NAME_SIDEBAR_COLLAPSE)
-
-    // Dispatch the "collapsed" event to indicate the sidebar is now collapsed.
 
     dispatchCustomEvent(this._element, EVENT_COLLAPSED)
   }
@@ -412,7 +384,7 @@ class PushMenu extends BaseComponent {
  * swaps. The instance itself is created per page load below and can be
  * retrieved anywhere with:
  *
- * PushMenu.getInstance(document.querySelector('.app-sidebar'))
+ *   PushMenu.getInstance(document.querySelector('.app-sidebar'))
  */
 
 document.addEventListener('click', event => {
@@ -430,9 +402,7 @@ document.addEventListener('click', event => {
 
   event.preventDefault()
 
-  const sidebar = document.querySelector(
-    SELECTOR_APP_SIDEBAR
-  ) as HTMLElement | null
+  const sidebar = document.querySelector(SELECTOR_APP_SIDEBAR) as HTMLElement | null
 
   if (sidebar) {
     PushMenu.getOrCreateInstance(sidebar).toggle()
@@ -442,9 +412,7 @@ document.addEventListener('click', event => {
 onDOMContentLoaded(() => {
   // Find the sidebar element in the DOM.
 
-  const sidebar = document.querySelector(
-    SELECTOR_APP_SIDEBAR
-  ) as HTMLElement | null
+  const sidebar = document.querySelector(SELECTOR_APP_SIDEBAR) as HTMLElement | null
 
   if (!sidebar) {
     return
@@ -478,9 +446,7 @@ onDOMContentLoaded(() => {
   // disturb a sidebar state the user chose. init() has already read the
   // effective breakpoint from the CSS, so the query uses the final value.
 
-  const breakpointQuery = globalThis.matchMedia(
-    `(max-width: ${pushMenu._config.sidebarBreakpoint}px)`
-  )
+  const breakpointQuery = globalThis.matchMedia(`(max-width: ${pushMenu._config.sidebarBreakpoint}px)`)
 
   breakpointQuery.addEventListener('change', () => {
     pushMenu.updateStateByResponsiveLogic()
@@ -492,9 +458,7 @@ onDOMContentLoaded(() => {
   // after the restore — the snapshot is a clone — so they are rebound below).
 
   const appWrapper = document.querySelector(SELECTOR_APP_WRAPPER)
-  let sidebarOverlay = appWrapper?.querySelector(
-    `:scope > .${CLASS_NAME_SIDEBAR_OVERLAY}`
-  ) as HTMLElement | null
+  let sidebarOverlay = appWrapper?.querySelector(`:scope > .${CLASS_NAME_SIDEBAR_OVERLAY}`) as HTMLElement | null
 
   if (!sidebarOverlay) {
     sidebarOverlay = document.createElement('div')
@@ -530,11 +494,5 @@ onDOMContentLoaded(() => {
     pushMenu.collapse()
   })
 })
-
-/**
- * ----------------------------------------------------------------------------
- * Exports
- * ----------------------------------------------------------------------------
- */
 
 export default PushMenu

--- a/src/ts/push-menu.ts
+++ b/src/ts/push-menu.ts
@@ -76,20 +76,51 @@ const Defaults: Config = {
  */
 
 class PushMenu extends BaseComponent {
+  /**
+   * Get the component name.
+   *
+   * @returns The component name.
+   */
   static get NAME(): string {
     return NAME
   }
 
+  /**
+   * Get the component instance associated with the given element, if any.
+   *
+   * @param element The element to look up.
+   * @returns The component instance, or null if none.
+   */
   static getInstance(element: Element | null | undefined): PushMenu | null {
     return this._getInstance(element) as PushMenu | null
   }
 
-  static getOrCreateInstance(element: HTMLElement, config: Partial<Config> = {}): PushMenu {
+  /**
+   * Get the component instance associated with the given element, or create a
+   * new one if none exists.
+   *
+   * @param element The element to look up or associate with a new instance.
+   * @param config Optional configuration for a new instance.
+   * @returns The component instance.
+   */
+  static getOrCreateInstance(
+    element: HTMLElement,
+    config: Partial<Config> = {}
+  ): PushMenu {
     return this.getInstance(element) ?? new this(element, config)
   }
 
+  /**
+   * The configuration for this instance.
+   */
   _config: Config
 
+  /**
+   * Create a new PushMenu instance associated with the given element.
+   *
+   * @param element The element to associate with this instance.
+   * @param config Optional configuration for this instance.
+   */
   constructor(element: HTMLElement, config: Partial<Config> = {}) {
     super(element)
     this._config = { ...Defaults, ...config }
@@ -136,9 +167,16 @@ class PushMenu extends BaseComponent {
    * Expand the sidebar menu.
    */
   expand(): void {
-    // The "open" event is cancelable: preventDefault() keeps the sidebar
-    // in its current state.
-    if (dispatchCustomEvent(this._element, EVENT_OPEN, { cancelable: true }).defaultPrevented) {
+    // Dispatch the "open" event, which is cancelable: preventDefault() should
+    // keep the sidebar in its current state.
+
+    const evt = dispatchCustomEvent(
+      this._element,
+      EVENT_OPEN,
+      { cancelable: true }
+    )
+
+    if (evt.defaultPrevented) {
       return
     }
 
@@ -151,6 +189,8 @@ class PushMenu extends BaseComponent {
       document.body.classList.add(CLASS_NAME_SIDEBAR_OPEN)
     }
 
+    // Dispatch the "opened" event to indicate the sidebar is now open.
+
     dispatchCustomEvent(this._element, EVENT_OPENED)
   }
 
@@ -158,7 +198,16 @@ class PushMenu extends BaseComponent {
    * Collapse the sidebar menu.
    */
   collapse(): void {
-    if (dispatchCustomEvent(this._element, EVENT_COLLAPSE, { cancelable: true }).defaultPrevented) {
+    // Dispatch the "collapse" event, which is cancelable: preventDefault()
+    // should keep the sidebar in its current state.
+
+    const evt = dispatchCustomEvent(
+      this._element,
+      EVENT_COLLAPSE,
+      { cancelable: true }
+    )
+
+    if (evt.defaultPrevented) {
       return
     }
 
@@ -167,6 +216,8 @@ class PushMenu extends BaseComponent {
 
     document.body.classList.remove(CLASS_NAME_SIDEBAR_OPEN)
     document.body.classList.add(CLASS_NAME_SIDEBAR_COLLAPSE)
+
+    // Dispatch the "collapsed" event to indicate the sidebar is now collapsed.
 
     dispatchCustomEvent(this._element, EVENT_COLLAPSED)
   }
@@ -361,7 +412,7 @@ class PushMenu extends BaseComponent {
  * swaps. The instance itself is created per page load below and can be
  * retrieved anywhere with:
  *
- *   PushMenu.getInstance(document.querySelector('.app-sidebar'))
+ * PushMenu.getInstance(document.querySelector('.app-sidebar'))
  */
 
 document.addEventListener('click', event => {
@@ -379,7 +430,9 @@ document.addEventListener('click', event => {
 
   event.preventDefault()
 
-  const sidebar = document.querySelector(SELECTOR_APP_SIDEBAR) as HTMLElement | null
+  const sidebar = document.querySelector(
+    SELECTOR_APP_SIDEBAR
+  ) as HTMLElement | null
 
   if (sidebar) {
     PushMenu.getOrCreateInstance(sidebar).toggle()
@@ -389,7 +442,9 @@ document.addEventListener('click', event => {
 onDOMContentLoaded(() => {
   // Find the sidebar element in the DOM.
 
-  const sidebar = document.querySelector(SELECTOR_APP_SIDEBAR) as HTMLElement | null
+  const sidebar = document.querySelector(
+    SELECTOR_APP_SIDEBAR
+  ) as HTMLElement | null
 
   if (!sidebar) {
     return
@@ -423,7 +478,9 @@ onDOMContentLoaded(() => {
   // disturb a sidebar state the user chose. init() has already read the
   // effective breakpoint from the CSS, so the query uses the final value.
 
-  const breakpointQuery = globalThis.matchMedia(`(max-width: ${pushMenu._config.sidebarBreakpoint}px)`)
+  const breakpointQuery = globalThis.matchMedia(
+    `(max-width: ${pushMenu._config.sidebarBreakpoint}px)`
+  )
 
   breakpointQuery.addEventListener('change', () => {
     pushMenu.updateStateByResponsiveLogic()
@@ -435,7 +492,9 @@ onDOMContentLoaded(() => {
   // after the restore — the snapshot is a clone — so they are rebound below).
 
   const appWrapper = document.querySelector(SELECTOR_APP_WRAPPER)
-  let sidebarOverlay = appWrapper?.querySelector(`:scope > .${CLASS_NAME_SIDEBAR_OVERLAY}`) as HTMLElement | null
+  let sidebarOverlay = appWrapper?.querySelector(
+    `:scope > .${CLASS_NAME_SIDEBAR_OVERLAY}`
+  ) as HTMLElement | null
 
   if (!sidebarOverlay) {
     sidebarOverlay = document.createElement('div')
@@ -471,5 +530,11 @@ onDOMContentLoaded(() => {
     pushMenu.collapse()
   })
 })
+
+/**
+ * ----------------------------------------------------------------------------
+ * Exports
+ * ----------------------------------------------------------------------------
+ */
 
 export default PushMenu


### PR DESCRIPTION
This pull request improves the code quality and maintainability of the `BaseComponent` and `PushMenu` classes by adding detailed documentation, clarifying lifecycle and registry management, and enhancing code readability.

**Documentation and Code Clarity Improvements:**

* Added comprehensive JSDoc-style comments and explanations to `BaseComponent`, its registry, and its lifecycle methods, making subclassing and usage clearer for future maintainers.
* Improved documentation for the `dispatchCustomEvent` utility, clarifying its parameters and return value.

**Component API and Lifecycle Enhancements:**

* Documented and clarified the API for `PushMenu`, including static methods like `getInstance` and `getOrCreateInstance`, and the constructor, making it easier to understand how to instantiate and interact with the component.

**Event Handling Consistency:**

* Refactored event dispatching in `PushMenu` methods (`expand` and `collapse`) for clarity: events are now stored in variables, and comments explain their cancelable behavior; added comments for "opened" and "collapsed" events.

**Code Formatting and Readability:**

* Reformatted long lines and query selectors for better readability, especially in DOM queries and media queries.

**Exports Organization:**

* Added explicit export blocks at the end of both files for clarity and maintainability.