### PR TITLE
Fix AdminLTE for other SPA frameworks like GWT

### DIFF
--- a/src/ts/adminlte.ts
+++ b/src/ts/adminlte.ts
@@ -1,4 +1,4 @@
-import { onDOMContentLoaded } from './util/index.js'
+import { initialize, onDOMContentLoaded } from './util/index.js'
 import Layout from './layout.js'
 import CardWidget from './card-widget.js'
 import Treeview from './treeview.js'
@@ -40,5 +40,6 @@ export {
   FullScreen,
   PushMenu,
   ColorMode,
-  initAccessibility
+  initAccessibility,
+  initialize
 }

--- a/src/ts/push-menu.ts
+++ b/src/ts/push-menu.ts
@@ -469,16 +469,23 @@ onDOMContentLoaded(() => {
   // Handle touch events on overlay (area outside sidebar), usually we want to
   // close the sidebar when the user taps outside the sidebar on mobile
   // devices.
+  //
+  // These are bound with the lifecycle signal even though the overlay lives
+  // inside <body>: the node above is reused when it already exists, so under a
+  // framework that re-initialises against a persistent <body>, an unsignalled
+  // binding would stack another set of handlers on the same element per cycle.
+
+  const overlaySignal = getLifecycleSignal()
 
   let overlayTouchMoved = false
 
   sidebarOverlay.addEventListener('touchstart', () => {
     overlayTouchMoved = false
-  }, { passive: true })
+  }, { passive: true, signal: overlaySignal })
 
   sidebarOverlay.addEventListener('touchmove', () => {
     overlayTouchMoved = true
-  }, { passive: true })
+  }, { passive: true, signal: overlaySignal })
 
   sidebarOverlay.addEventListener('touchend', event => {
     if (!overlayTouchMoved) {
@@ -487,12 +494,12 @@ onDOMContentLoaded(() => {
     }
 
     overlayTouchMoved = false
-  }, { passive: false })
+  }, { passive: false, signal: overlaySignal })
 
   sidebarOverlay.addEventListener('click', event => {
     event.preventDefault()
     pushMenu.collapse()
-  })
+  }, { signal: overlaySignal })
 })
 
 export default PushMenu

--- a/src/ts/util/index.ts
+++ b/src/ts/util/index.ts
@@ -16,6 +16,18 @@
  * cycle's listeners before the callbacks run again. Listeners bound to elements
  * inside <body> don't need the signal — Turbo discards the old <body>, so they
  * are cleaned up automatically.
+ *
+ * Turbo is not the only environment that renders after `DOMContentLoaded`:
+ * client-side frameworks that build the layout themselves (GWT, and other
+ * imperative widget toolkits) have an empty <body> when the initial batch runs,
+ * so the per-page init pass finds no sidebar and no menu. Those consumers call
+ * the exported `initialize()` once the layout is attached — it performs the same
+ * reset-then-replay cycle Turbo gets, without faking Turbo events.
+ *
+ * Unlike Turbo, such frameworks keep the same <body> across a re-init, so
+ * element-level listeners are NOT discarded for them. Callbacks should therefore
+ * pass `getLifecycleSignal()` to every `addEventListener` they make — including
+ * ones on elements — whenever the element can outlive the cycle.
  */
 
 const lifecycleCallbacks: Array<() => void> = []
@@ -58,6 +70,34 @@ const onDOMContentLoaded = (callback: () => void): void => {
   }
 }
 
+/**
+ * End the current lifecycle: abort the cycle's signal so listeners registered
+ * with it are removed, then arm a fresh cycle for the next replay.
+ */
+const resetLifecycle = (): void => {
+  lifecycleState.controller.abort()
+  lifecycleState.controller = new AbortController()
+  lifecycleState.hasInitialized = false
+}
+
+/**
+ * Re-run every plugin's initialisation against the DOM as it stands right now.
+ *
+ * Intended for frameworks that render the layout after `DOMContentLoaded` has
+ * already fired — call it once the sidebar and menu are attached, and PushMenu,
+ * Treeview and ColorMode pick them up as if they had been in the initial HTML.
+ * Delegated click handling never needs this; only the per-page init pass does.
+ *
+ * The previous cycle is torn down first, so calling it repeatedly does not stack
+ * listeners registered with `getLifecycleSignal()`. Calling it before the
+ * initial batch has run (while `document.readyState === 'loading'`) simply runs
+ * that batch early, against whatever DOM exists at the time.
+ */
+const initialize = (): void => {
+  resetLifecycle()
+  runLifecycleCallbacks()
+}
+
 // Initial page load.
 if (document.readyState === 'loading') {
   document.addEventListener('DOMContentLoaded', runLifecycleCallbacks, { once: true })
@@ -66,12 +106,11 @@ if (document.readyState === 'loading') {
 }
 
 // Hotwired Turbo: drop the previous cycle's window/document listeners, then
-// re-run initialisation against the freshly rendered <body>.
-document.addEventListener('turbo:before-render', () => {
-  lifecycleState.controller.abort()
-  lifecycleState.controller = new AbortController()
-  lifecycleState.hasInitialized = false
-})
+// re-run initialisation against the freshly rendered <body>. The teardown has to
+// happen at `before-render` rather than as part of the replay, so the outgoing
+// <body>'s listeners are gone before Turbo swaps in the new one — which is why
+// this is the two-step form of `initialize()` rather than a call to it.
+document.addEventListener('turbo:before-render', resetLifecycle)
 
 document.addEventListener('turbo:load', runLifecycleCallbacks)
 
@@ -219,6 +258,7 @@ const slideToggle = (target: HTMLElement, duration = 500) => {
 export {
   onDOMContentLoaded,
   getLifecycleSignal,
+  initialize,
   slideUp,
   slideDown,
   slideToggle,

--- a/tests/unit/util.test.ts
+++ b/tests/unit/util.test.ts
@@ -53,3 +53,66 @@ describe('slide animations', () => {
     expect(element.style.height).toBe('')
   })
 })
+
+/**
+ * The lifecycle module keeps state at module scope and runs its initial batch on
+ * import, so every test imports a fresh instance. `document.readyState` is
+ * 'complete' under happy-dom, which means a callback registered here runs once
+ * immediately via the late-registration path.
+ */
+describe('lifecycle', () => {
+  beforeEach(() => {
+    vi.resetModules()
+  })
+
+  it('initialize() replays registered callbacks against the current DOM', async () => {
+    const { initialize, onDOMContentLoaded } = await import('../../src/ts/util/index')
+    const callback = vi.fn()
+
+    onDOMContentLoaded(callback)
+    expect(callback).toHaveBeenCalledTimes(1)
+
+    initialize()
+    expect(callback).toHaveBeenCalledTimes(2)
+
+    // Repeated calls keep replaying — frameworks may re-render more than once.
+    initialize()
+    expect(callback).toHaveBeenCalledTimes(3)
+  })
+
+  it('initialize() aborts the previous cycle so signalled listeners do not stack', async () => {
+    const { getLifecycleSignal, initialize, onDOMContentLoaded } = await import('../../src/ts/util/index')
+    const handler = vi.fn()
+
+    onDOMContentLoaded(() => {
+      document.addEventListener('lte.test.ping', handler, { signal: getLifecycleSignal() })
+    })
+
+    document.dispatchEvent(new Event('lte.test.ping'))
+    expect(handler).toHaveBeenCalledTimes(1)
+
+    initialize()
+    handler.mockClear()
+
+    // Two registrations have happened, but the first cycle's signal was aborted,
+    // so exactly one listener is still live.
+    document.dispatchEvent(new Event('lte.test.ping'))
+    expect(handler).toHaveBeenCalledTimes(1)
+  })
+
+  it('turbo:load replays only once turbo:before-render has reset the cycle', async () => {
+    const { onDOMContentLoaded } = await import('../../src/ts/util/index')
+    const callback = vi.fn()
+
+    onDOMContentLoaded(callback)
+    callback.mockClear()
+
+    // The cycle is still marked initialised, so a bare turbo:load is a no-op.
+    document.dispatchEvent(new Event('turbo:load'))
+    expect(callback).not.toHaveBeenCalled()
+
+    document.dispatchEvent(new Event('turbo:before-render'))
+    document.dispatchEvent(new Event('turbo:load'))
+    expect(callback).toHaveBeenCalledTimes(1)
+  })
+})


### PR DESCRIPTION
This pull request improves AdminLTE's compatibility with GWT and other SPAs that have a race condition with AdminLTE after DOMContentLoaded is triggered but doesn't discard the body like Turbo.

For GWT users: you only need to call initAdminLTE after you handle current history.

```
	public static void initAdminLTE() {
		Scheduler.get().scheduleDeferred(AdminLTE::initAdminLte);
	}
	private static native void initAdminLte() /*-{
		$wnd.adminlte.initialize();
	}-*/;
```